### PR TITLE
Fix pinned card title fade layout

### DIFF
--- a/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
@@ -8,6 +8,10 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -28,6 +32,7 @@ import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.fadeRightEdge
 import com.kippu.trace.utils.fadeLastLineEdge
+import com.kippu.trace.utils.getLastLineHeightFraction
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -86,6 +91,8 @@ fun PinnedEventCard(
                 val visualWidth = TextUtils.getVisualWidth(event.title)
                 
                 if (visualWidth > 15.0f) {
+                    var titleLineCount by remember(event.title) { mutableStateOf(1) }
+
                     // 类型 3：4 行 带超强淡出
                     Row(
                         modifier = Modifier.fillMaxSize(),
@@ -96,11 +103,16 @@ fun PinnedEventCard(
                             text = TextUtils.forceCharacterWrap(event.title),
                             modifier = Modifier
                                 .weight(1f)
-                                .fillMaxHeight()
-                                .wrapContentHeight(Alignment.Bottom)
                                 .padding(end = 16.dp)
-                                .fadeLastLineEdge(fadeWidth = 48.dp),
+                                .fadeLastLineEdge(
+                                    fadeWidth = 48.dp,
+                                    lastLineHeightFraction = getLastLineHeightFraction(titleLineCount)
+                                ),
                             maxLines = 4,
+                            onTextLayout = {
+                                // 按真实可见行数计算最后一行区域，避免底部文字被半透明蒙版影响。
+                                titleLineCount = it.lineCount.coerceAtLeast(1)
+                            },
                             overflow = androidx.compose.ui.text.style.TextOverflow.Clip,
                             style = MaterialTheme.typography.titleLarge.copy(
                                 color = Color.White,

--- a/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
@@ -10,6 +10,11 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+// 根据实际可见行数计算最后一行占比，避免只淡出文字下半部分。
+fun getLastLineHeightFraction(lineCount: Int): Float {
+    return 1f / lineCount.coerceAtLeast(1)
+}
+
 // 右侧边缘淡出效果
 fun Modifier.fadeRightEdge(
     fadeWidth: Dp = 48.dp // 增加 提高可见度


### PR DESCRIPTION
# 修复置顶卡片长标题末行淡出位置不准确

## 背景

置顶卡片的长标题实际只显示为 2 行时，原来的长标题分支会按固定的 4 行比例处理最后一行淡出区域，导致淡出蒙版位置不准确。

## 原因

长标题分支里，`Text` 原先使用了 `fillMaxHeight()` 和 `wrapContentHeight(Alignment.Bottom)`。

这会让文本布局区域撑满父级高度，再把实际文字内容贴到底部显示。与此同时，`fadeLastLineEdge()` 默认使用 `lastLineHeightFraction = 0.25f` 来计算最后一行淡出区域，相当于按 4 行文本的比例处理最后一行。

当标题实际只显示为 2 行或 3 行时，淡出区域仍然按固定比例计算，和真实文本行数不完全匹配。再加上 `Text` 布局区域被撑高，淡出蒙版可能作用到不准确的位置，从而让部分可见文字出现轻微半透明或色差。

## 修改

本 PR 做了以下调整：

- 移除长标题 `Text` 上的 `fillMaxHeight()` 和 `wrapContentHeight(Alignment.Bottom)`
- 保留外层 `Row(verticalAlignment = Alignment.Bottom)` 负责底部对齐
- 通过 `onTextLayout` 获取标题实际显示行数
- 根据实际行数计算最后一行高度占比
- 让 `fadeLastLineEdge()` 按真实文本高度和真实行数计算淡出区域

## 影响范围

仅影响置顶卡片的长标题分支：

```kotlin
if (visualWidth > 15.0f) {
    ...
}
```

## 验证

可使用较长的中日英混排标题进行手动验证，在标题实际显示为 2 行或 3 行时，末尾文字不应再出现异常变淡或色差。

## 补充说明

现有的 `visualWidth > 15.0f` 长标题分支判断这个阈值本身是基于字符类型的估算值，并不等同于真实文本排版结果。实际是否换行或溢出还会受到设备宽度、字体渲染、系统字体缩放和中日英混排规则等因素影响。

因此，`visualWidth > 15.0f` 更适合用于粗略选择布局，不太适合作为判断文本是否需要淡出或是否发生溢出的唯一依据。后续如果想要优化的话，可以考虑更多使用 `TextLayoutResult` 的实际测量结果~
