### PR TITLE
小组件布局与显示优化/主页卡片支持平板双列布局

### DIFF
--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -11,7 +11,12 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -127,34 +132,69 @@ fun HomeScreen(
                 Text(text = stringResource(R.string.empty_timeline_hint), style = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.secondary))
             }
         } else {
-            LazyColumn(
-                state = lazyListState,
-                modifier = Modifier.fillMaxSize().padding(innerPadding),
-                contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 120.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                itemsIndexed(pinnedEventsState, key = { _, it -> "pinned_${it.id}" }) { _, event ->
-                    SwipeActionWrapper(
-                        isResetRequested = editingEvent == null && eventToDelete == null,
-                        isDeleting = eventToDelete?.id == event.id,
-                        isEditing = editingEvent?.id == event.id,
-                        onTrashClick = { eventToDelete = event },
-                        onEditClick = { editingEvent = event }
-                    ) {
-                        // 编辑中的卡片直接读取 editingEvent 实时预览改动
-                        PinnedEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
-                    }
-                }
+            val gridState = rememberLazyGridState()
+            BoxWithConstraints(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                val columns = if (maxWidth >= 600.dp) 2 else 1
 
-                itemsIndexed(otherEventsState, key = { _, it -> it.id }) { _, event ->
-                    SwipeActionWrapper(
-                        isResetRequested = editingEvent == null && eventToDelete == null,
-                        isDeleting = eventToDelete?.id == event.id,
-                        isEditing = editingEvent?.id == event.id,
-                        onTrashClick = { eventToDelete = event },
-                        onEditClick = { editingEvent = event }
+                if (columns == 1) {
+                    // 手机：单列布局
+                    LazyColumn(
+                        state = lazyListState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 120.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        NormalEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
+                        itemsIndexed(pinnedEventsState, key = { _, it -> "pinned_${it.id}" }) { _, event ->
+                            SwipeActionWrapper(
+                                isResetRequested = editingEvent == null && eventToDelete == null,
+                                isDeleting = eventToDelete?.id == event.id,
+                                isEditing = editingEvent?.id == event.id,
+                                onTrashClick = { eventToDelete = event },
+                                onEditClick = { editingEvent = event }
+                            ) {
+                                // 编辑中的卡片直接读取 editingEvent 实时预览改动
+                                PinnedEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
+                            }
+                        }
+
+                        itemsIndexed(otherEventsState, key = { _, it -> it.id }) { _, event ->
+                            SwipeActionWrapper(
+                                isResetRequested = editingEvent == null && eventToDelete == null,
+                                isDeleting = eventToDelete?.id == event.id,
+                                isEditing = editingEvent?.id == event.id,
+                                onTrashClick = { eventToDelete = event },
+                                onEditClick = { editingEvent = event }
+                            ) {
+                                NormalEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
+                            }
+                        }
+                    }
+                } else {
+                    // 平板：双列网格布局
+                    val allEvents = pinnedEventsState.toList() + otherEventsState.toList()
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(2),
+                        state = gridState,
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 120.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        items(allEvents, key = { "grid_${it.id}" }) { event ->
+                            SwipeActionWrapper(
+                                isResetRequested = editingEvent == null && eventToDelete == null,
+                                isDeleting = eventToDelete?.id == event.id,
+                                isEditing = editingEvent?.id == event.id,
+                                onTrashClick = { eventToDelete = event },
+                                onEditClick = { editingEvent = event }
+                            ) {
+                                if (event.isPinned) {
+                                    PinnedEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
+                                } else {
+                                    NormalEventCard(event = if (editingEvent?.id == event.id) editingEvent!! else event, onClick = { onEventClick(event) })
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/kippu/trace/widget/TraceWidgetUpdater.kt
+++ b/app/src/main/java/com/kippu/trace/widget/TraceWidgetUpdater.kt
@@ -13,11 +13,15 @@ import com.kippu.trace.MainActivity
 import com.kippu.trace.R
 import com.kippu.trace.data.AppDatabase
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.utils.LanguageMode
+import com.kippu.trace.utils.LanguagePreferences
+import com.kippu.trace.utils.TextUtils
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -111,6 +115,21 @@ object TraceWidgetUpdater {
         }
     }
 
+    // 获取与应用内语言设置一致的本地化 Context
+    private fun getLocalizedContext(context: Context): Context {
+        val mode = LanguagePreferences.getLanguageMode(context)
+        val locale = when (mode) {
+            LanguageMode.SYSTEM -> Locale.getDefault()
+            LanguageMode.CHINESE -> Locale("zh")
+            LanguageMode.ENGLISH -> Locale("en")
+            LanguageMode.JAPANESE -> Locale("ja")
+        }
+        val config = Configuration(context.resources.configuration).apply {
+            setLocale(locale)
+        }
+        return context.createConfigurationContext(config)
+    }
+
     // 构建远程视图并填充数据
     private fun buildRemoteViews(context: Context, widgetSize: TraceWidgetSize, event: DateEvent?, appWidgetId: Int, widthPx: Int, heightPx: Int): RemoteViews {
         val views = RemoteViews(context.packageName, widgetSize.layoutRes)
@@ -145,18 +164,19 @@ object TraceWidgetUpdater {
 
             val dateText = formatTargetDate(event.targetDate)
             val days = calculateDays(event.targetDate).toString()
-            val prefix = context.getString(if (event.isFuture) R.string.label_until else R.string.label_since)
+            val localizedCtx = getLocalizedContext(context)
+            val prefix = localizedCtx.getString(if (event.isFuture) R.string.label_until else R.string.label_since)
 
             views.setTextViewText(R.id.widget_title, event.title)
             views.setTextViewText(R.id.widget_prefix, prefix)
             views.setTextViewText(R.id.widget_date, dateText)
             views.setTextViewText(R.id.widget_days, days)
-            views.setTextViewText(R.id.widget_day_unit, context.getString(R.string.day_unit))
+            views.setTextViewText(R.id.widget_day_unit, localizedCtx.getString(R.string.day_unit))
             
             views.setViewVisibility(R.id.widget_prefix, View.VISIBLE)
             views.setViewVisibility(R.id.widget_date, View.VISIBLE)
             
-            applySizeTuning(views, widgetSize)
+            applySizeTuning(views, widgetSize, event.title, days.toLong())
             // 点击有内容的小组件直接打开对应卡片详情页
             views.setOnClickPendingIntent(R.id.widget_root, createOpenAppIntent(context, event.id))
         }
@@ -164,22 +184,48 @@ object TraceWidgetUpdater {
         return views
     }
 
-    private fun applySizeTuning(views: RemoteViews, widgetSize: TraceWidgetSize) {
+    private fun applySizeTuning(views: RemoteViews, widgetSize: TraceWidgetSize, title: String, daysCount: Long) {
+        val isLongTitle = title.length > 8 || TextUtils.getVisualWidth(title) > 15f
+        val isLargeDays = daysCount >= 1000
+
         when (widgetSize) {
             TraceWidgetSize.TWO_BY_TWO -> {
-                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, 16f)
-                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, 40f)
-                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, 12f)
+                val (titleSize, daysSize, prefixSize, unitSize) = when {
+                    isLongTitle && isLargeDays -> arrayOf(13f, 22f, 9f, 10f)
+                    isLargeDays -> arrayOf(14f, 26f, 10f, 11f)
+                    isLongTitle -> arrayOf(14f, 32f, 11f, 12f)
+                    else -> arrayOf(16f, 32f, 11f, 12f)
+                }
+                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, titleSize)
+                views.setTextViewTextSize(R.id.widget_prefix, TypedValue.COMPLEX_UNIT_SP, prefixSize)
+                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, daysSize)
+                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, unitSize)
+                // 2x2 空间有限，不显示年月日
+                views.setViewVisibility(R.id.widget_date, View.GONE)
             }
             TraceWidgetSize.THREE_BY_TWO -> {
-                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, 17f)
-                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, 42f)
-                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, 13f)
+                val (titleSize, daysSize, prefixSize, unitSize) = when {
+                    isLongTitle && isLargeDays -> arrayOf(17f, 30f, 10f, 11f)
+                    isLargeDays -> arrayOf(18f, 34f, 11f, 12f)
+                    isLongTitle -> arrayOf(18f, 42f, 12f, 13f)
+                    else -> arrayOf(20f, 42f, 12f, 13f)
+                }
+                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, titleSize)
+                views.setTextViewTextSize(R.id.widget_prefix, TypedValue.COMPLEX_UNIT_SP, prefixSize)
+                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, daysSize)
+                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, unitSize)
             }
             TraceWidgetSize.FOUR_BY_TWO -> {
-                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, 22f)
-                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, 48f)
-                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, 14f)
+                val (titleSize, daysSize, prefixSize, unitSize) = when {
+                    isLongTitle && isLargeDays -> arrayOf(18f, 28f, 12f, 12f)
+                    isLargeDays -> arrayOf(19f, 32f, 13f, 13f)
+                    isLongTitle -> arrayOf(20f, 40f, 14f, 14f)
+                    else -> arrayOf(22f, 40f, 14f, 14f)
+                }
+                views.setTextViewTextSize(R.id.widget_title, TypedValue.COMPLEX_UNIT_SP, titleSize)
+                views.setTextViewTextSize(R.id.widget_prefix, TypedValue.COMPLEX_UNIT_SP, prefixSize)
+                views.setTextViewTextSize(R.id.widget_days, TypedValue.COMPLEX_UNIT_SP, daysSize)
+                views.setTextViewTextSize(R.id.widget_day_unit, TypedValue.COMPLEX_UNIT_SP, unitSize)
             }
         }
     }

--- a/app/src/main/res/layout/widget_trace_2x2.xml
+++ b/app/src/main/res/layout/widget_trace_2x2.xml
@@ -66,21 +66,16 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:gravity="bottom"
                 android:orientation="vertical">
-
-                <TextView
-                    android:id="@+id/widget_prefix"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:includeFontPadding="false"
-                    android:textColor="#CCFFFFFF"
-                    android:textSize="11sp" />
 
                 <TextView
                     android:id="@+id/widget_date"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
                     android:includeFontPadding="false"
+                    android:singleLine="true"
                     android:textColor="#B3FFFFFF"
                     android:textSize="10sp" />
             </LinearLayout>
@@ -90,6 +85,15 @@
                 android:layout_height="wrap_content"
                 android:gravity="bottom"
                 android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/widget_prefix"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="2dp"
+                    android:includeFontPadding="false"
+                    android:textColor="#CCFFFFFF"
+                    android:textSize="11sp" />
 
                 <TextView
                     android:id="@+id/widget_days"

--- a/app/src/main/res/layout/widget_trace_3x2.xml
+++ b/app/src/main/res/layout/widget_trace_3x2.xml
@@ -70,19 +70,12 @@
                 android:orientation="horizontal">
 
                 <TextView
-                    android:id="@+id/widget_prefix"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:includeFontPadding="false"
-                    android:textColor="#CCFFFFFF"
-                    android:textSize="12sp" />
-
-                <TextView
                     android:id="@+id/widget_date"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="5dp"
+                    android:ellipsize="end"
                     android:includeFontPadding="false"
+                    android:singleLine="true"
                     android:textColor="#B3FFFFFF"
                     android:textSize="12sp" />
             </LinearLayout>
@@ -93,6 +86,15 @@
             android:layout_height="wrap_content"
             android:gravity="bottom"
             android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/widget_prefix"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="3dp"
+                android:includeFontPadding="false"
+                android:textColor="#CCFFFFFF"
+                android:textSize="12sp" />
 
             <TextView
                 android:id="@+id/widget_days"

--- a/app/src/main/res/layout/widget_trace_4x2.xml
+++ b/app/src/main/res/layout/widget_trace_4x2.xml
@@ -73,11 +73,13 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="6dp"
+                android:ellipsize="end"
                 android:includeFontPadding="false"
                 android:shadowColor="#40000000"
                 android:shadowDx="0"
                 android:shadowDy="1"
                 android:shadowRadius="2"
+                android:singleLine="true"
                 android:textColor="#B3FFFFFF"
                 android:textSize="12sp" />
         </LinearLayout>
@@ -88,6 +90,19 @@
             android:layout_height="wrap_content"
             android:gravity="bottom"
             android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/widget_prefix"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="4dp"
+                android:includeFontPadding="false"
+                android:shadowColor="#40000000"
+                android:shadowDx="0"
+                android:shadowDy="1"
+                android:shadowRadius="2"
+                android:textColor="#CCFFFFFF"
+                android:textSize="14sp" />
 
             <TextView
                 android:id="@+id/widget_days"
@@ -119,11 +134,5 @@
                 android:textSize="14sp" />
         </LinearLayout>
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/widget_prefix"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:visibility="gone" />
 
 </FrameLayout>


### PR DESCRIPTION
使用 BoxWithConstraints 检测屏幕可用宽度
宽度 ≥ 600dp 时切换为 LazyVerticalGrid(columns = 2) 双列网格
宽度 < 600dp 时保持现有 LazyColumn 单列布局，行为完全不变
<img width="798" height="385" alt="image" src="https://github.com/user-attachments/assets/99e8501d-ce8c-4f4d-bd3e-31f1b602f773" />

**"还有""已经" 位置修正**
将 widget_prefix 从日期前移到天数前

**小组件语言跟随应用设置**
TraceWidgetUpdater 新增 getLocalizedContext()，读取 LanguagePreferences 创建本地化上下文，小组件的 "Until/Already/天" 等文字与应用内语言保持一致

**字体大小调整**
3x2 标题：17sp → 20sp（更大更清晰）
2x2 天数：40sp → 32sp、4x2 天数：48sp → 40sp（防止大数字溢出）

**布局溢出修复**
所有 widget 的日期字段添加 singleLine + ellipsize，防止被挤压后竖排换行
applySizeTuning 按标题长度（>8字）和天数字数（≥1000）动态缩小字体，四位数时各组件字体递进缩小 2-4sp
2x2 直接隐藏年月日