### PR TITLE
feat: anniversary display, countdown auto-repeat, date-picker wizard & docs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+        }
         release {
             isMinifyEnabled = true
             proguardFiles(

--- a/app/src/androidTest/java/com/kippu/trace/data/AppDatabaseMigrationTest.kt
+++ b/app/src/androidTest/java/com/kippu/trace/data/AppDatabaseMigrationTest.kt
@@ -1,0 +1,111 @@
+package com.kippu.trace.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigrationTest {
+    @Test
+    fun migrationFrom2To3PreservesEventsAndAddsDefaultSettings() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val databaseName = "migration-2-3-test.db"
+        context.deleteDatabase(databaseName)
+
+        createVersion2Database(context, databaseName)
+
+        val database = Room.databaseBuilder(context, AppDatabase::class.java, databaseName)
+            .addMigrations(AppDatabase.MIGRATION_2_3)
+            .build()
+
+        try {
+            val event = runBlocking { database.eventDao().getAllEventsOnce().single() }
+
+            assertEquals(7L, event.id)
+            assertEquals("Existing event", event.title)
+            assertEquals(1_234_567_890L, event.targetDate)
+            assertTrue(event.isFuture)
+            assertFalse(event.isLunar)
+            assertEquals(DisplayMode.COUNT_DOWN, event.mode)
+            assertNull(event.backgroundUri)
+            assertTrue(event.isPinned)
+            assertEquals(0.4f, event.maskOpacity)
+            assertEquals(3, event.position)
+            assertEquals(RepeatMode.NONE, event.repeatMode)
+            assertEquals(0, event.repeatCustomDays)
+            assertEquals(0, event.customAnniversaryDays)
+            assertFalse(event.anniversaryYearEnabled)
+            assertFalse(event.anniversaryMonthEnabled)
+            assertFalse(event.anniversaryWeekEnabled)
+            assertEquals("", event.anniversaryCombinedText)
+        } finally {
+            database.close()
+            context.deleteDatabase(databaseName)
+        }
+    }
+
+    private fun createVersion2Database(context: Context, databaseName: String) {
+        val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
+            .name(databaseName)
+            .callback(object : SupportSQLiteOpenHelper.Callback(2) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS `date_events` (
+                            `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                            `title` TEXT NOT NULL,
+                            `targetDate` INTEGER NOT NULL,
+                            `isFuture` INTEGER NOT NULL,
+                            `isLunar` INTEGER NOT NULL,
+                            `mode` TEXT NOT NULL,
+                            `backgroundUri` TEXT,
+                            `isPinned` INTEGER NOT NULL,
+                            `maskOpacity` REAL NOT NULL,
+                            `position` INTEGER NOT NULL
+                        )
+                        """.trimIndent()
+                    )
+                    db.execSQL(
+                        """
+                        INSERT INTO `date_events` (
+                            `id`, `title`, `targetDate`, `isFuture`, `isLunar`, `mode`,
+                            `backgroundUri`, `isPinned`, `maskOpacity`, `position`
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """.trimIndent(),
+                        arrayOf<Any?>(
+                            7L,
+                            "Existing event",
+                            1_234_567_890L,
+                            1,
+                            0,
+                            "COUNT_DOWN",
+                            null,
+                            1,
+                            0.4f,
+                            3,
+                        )
+                    )
+                }
+
+                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+            })
+            .build()
+
+        val helper = FrameworkSQLiteOpenHelperFactory().create(configuration)
+        helper.writableDatabase
+        helper.close()
+    }
+}

--- a/app/src/androidTest/java/com/kippu/trace/data/EventDaoCountdownUpdateTest.kt
+++ b/app/src/androidTest/java/com/kippu/trace/data/EventDaoCountdownUpdateTest.kt
@@ -1,0 +1,65 @@
+package com.kippu.trace.data
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class EventDaoCountdownUpdateTest {
+    @Test
+    fun conditionalAdvancePreservesOtherEditsAndRejectsAStaleTarget() = runBlocking {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
+
+        try {
+            val dao = database.eventDao()
+            val original = DateEvent(
+                id = 1,
+                title = "Original",
+                targetDate = 1_000L,
+                isFuture = false,
+                mode = DisplayMode.COUNT_DOWN,
+                repeatMode = RepeatMode.MONTHLY,
+                repeatAnchorDate = 1_000L,
+            )
+            dao.insertEvent(original)
+            dao.insertEvent(original.copy(title = "Edited while advancing"))
+
+            val updated = dao.advanceCountdownIfUnchanged(
+                id = original.id,
+                expectedTargetDate = original.targetDate,
+                expectedRepeatMode = original.repeatMode,
+                expectedCustomDays = original.repeatCustomDays,
+                expectedAnchorDate = original.repeatAnchorDate,
+                newTargetDate = 2_000L,
+                newAnchorDate = 1_000L,
+            )
+
+            assertEquals(1, updated)
+            assertEquals("Edited while advancing", dao.getEventById(original.id)?.title)
+
+            dao.insertEvent(dao.getEventById(original.id)!!.copy(targetDate = 3_000L))
+            val staleUpdate = dao.advanceCountdownIfUnchanged(
+                id = original.id,
+                expectedTargetDate = 2_000L,
+                expectedRepeatMode = original.repeatMode,
+                expectedCustomDays = original.repeatCustomDays,
+                expectedAnchorDate = original.repeatAnchorDate,
+                newTargetDate = 4_000L,
+                newAnchorDate = 1_000L,
+            )
+
+            assertEquals(0, staleUpdate)
+            assertEquals(3_000L, dao.getEventById(original.id)?.targetDate)
+        } finally {
+            database.close()
+        }
+    }
+}

--- a/app/src/main/java/com/kippu/trace/MainActivity.kt
+++ b/app/src/main/java/com/kippu/trace/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.kippu.trace
 
-import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -48,7 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.os.LocaleListCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.activity.viewModels
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -62,7 +61,6 @@ import com.kippu.trace.utils.LanguagePreferences
 import com.kippu.trace.utils.ThemeMode
 import com.kippu.trace.utils.ThemePreferences
 import com.kippu.trace.viewmodel.EventViewModel
-import com.kippu.trace.widget.TraceWidgetUpdater
 import java.time.Instant
 import java.time.ZoneId
 import java.util.Locale
@@ -73,6 +71,8 @@ class MainActivity : ComponentActivity() {
     // 小组件点击传入的 deep link eventId
     var deepLinkEventId by mutableStateOf<Long?>(null)
         private set
+
+    private val eventViewModel: EventViewModel by viewModels()
 
     // 专门用于强制同步状态栏的函数
     private fun forceUpdateSystemBars(isDark: Boolean) {
@@ -131,7 +131,6 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            val eventViewModel: EventViewModel = viewModel()
             val events by eventViewModel.allEvents.collectAsState()
             val context = this
             var themeMode by remember { mutableStateOf(ThemePreferences.getThemeMode(context)) }
@@ -175,6 +174,8 @@ class MainActivity : ComponentActivity() {
             ThemeMode.DARK -> true
         }
         forceUpdateSystemBars(isDark)
+        // 触发倒数模式自动推进检查
+        eventViewModel.checkAndAdvanceCountdowns()
     }
 
     // 处理小组件点击 deep link（App 已在后台时走 onNewIntent）

--- a/app/src/main/java/com/kippu/trace/MainActivity.kt
+++ b/app/src/main/java/com/kippu/trace/MainActivity.kt
@@ -58,11 +58,10 @@ import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.ui.theme.KIPPU_TraceTheme
 import com.kippu.trace.utils.LanguageMode
 import com.kippu.trace.utils.LanguagePreferences
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.ThemeMode
 import com.kippu.trace.utils.ThemePreferences
 import com.kippu.trace.viewmodel.EventViewModel
-import java.time.Instant
-import java.time.ZoneId
 import java.util.Locale
 import kotlinx.coroutines.launch
 
@@ -283,10 +282,7 @@ fun WidgetSelectionItem(event: DateEvent, onClick: () -> Unit) {
                     maxLines = 1
                 )
                 Text(
-                    text = Instant.ofEpochMilli(event.targetDate)
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate()
-                        .toString(),
+                    text = EventDateUtils.fromStoredMillis(event.targetDate).toString(),
                     color = Color.White.copy(alpha = 0.6f),
                     fontSize = 12.sp
                 )

--- a/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
+++ b/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
@@ -38,7 +38,7 @@ interface EventDao {
     }
 }
 
-@Database(entities = [DateEvent::class], version = 2, exportSchema = false)
+@Database(entities = [DateEvent::class], version = 3, exportSchema = false)
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun eventDao(): EventDao

--- a/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
+++ b/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
@@ -58,6 +58,9 @@ abstract class AppDatabase : RoomDatabase() {
                     "ALTER TABLE `date_events` ADD COLUMN `repeatCustomDays` INTEGER NOT NULL DEFAULT 0"
                 )
                 db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `repeatAnchorDate` INTEGER"
+                )
+                db.execSQL(
                     "ALTER TABLE `date_events` ADD COLUMN `customAnniversaryDays` INTEGER NOT NULL DEFAULT 0"
                 )
                 db.execSQL(

--- a/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
+++ b/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.*
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.RepeatMode
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -26,6 +27,33 @@ interface EventDao {
 
     @Update
     suspend fun updateEvents(events: List<DateEvent>)
+
+    @Query(
+        """
+        UPDATE date_events
+        SET targetDate = :newTargetDate,
+            isFuture = 1,
+            repeatAnchorDate = :newAnchorDate
+        WHERE id = :id
+          AND mode = 'COUNT_DOWN'
+          AND targetDate = :expectedTargetDate
+          AND repeatMode = :expectedRepeatMode
+          AND repeatCustomDays = :expectedCustomDays
+          AND (
+              (repeatAnchorDate IS NULL AND :expectedAnchorDate IS NULL)
+              OR repeatAnchorDate = :expectedAnchorDate
+          )
+        """
+    )
+    suspend fun advanceCountdownIfUnchanged(
+        id: Long,
+        expectedTargetDate: Long,
+        expectedRepeatMode: RepeatMode,
+        expectedCustomDays: Int,
+        expectedAnchorDate: Long?,
+        newTargetDate: Long,
+        newAnchorDate: Long,
+    ): Int
 
     @Query("DELETE FROM date_events")
     suspend fun deleteAll()

--- a/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
+++ b/app/src/main/java/com/kippu/trace/data/AppDatabase.kt
@@ -2,6 +2,8 @@ package com.kippu.trace.data
 
 import android.content.Context
 import androidx.room.*
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.kippu.trace.model.DateEvent
 import kotlinx.coroutines.flow.Flow
 
@@ -47,6 +49,32 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `repeatMode` TEXT NOT NULL DEFAULT 'NONE'"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `repeatCustomDays` INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `customAnniversaryDays` INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `anniversaryYearEnabled` INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `anniversaryMonthEnabled` INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `anniversaryWeekEnabled` INTEGER NOT NULL DEFAULT 0"
+                )
+                db.execSQL(
+                    "ALTER TABLE `date_events` ADD COLUMN `anniversaryCombinedText` TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -54,7 +82,8 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "trace_database",
                 )
-                .fallbackToDestructiveMigration()
+                .addMigrations(MIGRATION_2_3)
+                .fallbackToDestructiveMigrationFrom(1)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/kippu/trace/data/Converters.kt
+++ b/app/src/main/java/com/kippu/trace/data/Converters.kt
@@ -2,6 +2,7 @@ package com.kippu.trace.data
 
 import androidx.room.TypeConverter
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
 
 class Converters {
     @TypeConverter
@@ -12,5 +13,15 @@ class Converters {
     @TypeConverter
     fun toDisplayMode(mode: String): DisplayMode {
         return DisplayMode.valueOf(mode)
+    }
+
+    @TypeConverter
+    fun fromRepeatMode(mode: RepeatMode): String {
+        return mode.name
+    }
+
+    @TypeConverter
+    fun toRepeatMode(mode: String): RepeatMode {
+        return RepeatMode.valueOf(mode)
     }
 }

--- a/app/src/main/java/com/kippu/trace/data/EventRepository.kt
+++ b/app/src/main/java/com/kippu/trace/data/EventRepository.kt
@@ -26,6 +26,20 @@ class EventRepository(private val eventDao: EventDao) {
         eventDao.updateEvents(events)
     }
 
+    suspend fun advanceCountdownIfUnchanged(
+        event: DateEvent,
+        newTargetDate: Long,
+        newAnchorDate: Long,
+    ): Boolean = eventDao.advanceCountdownIfUnchanged(
+        id = event.id,
+        expectedTargetDate = event.targetDate,
+        expectedRepeatMode = event.repeatMode,
+        expectedCustomDays = event.repeatCustomDays,
+        expectedAnchorDate = event.repeatAnchorDate,
+        newTargetDate = newTargetDate,
+        newAnchorDate = newAnchorDate,
+    ) == 1
+
     suspend fun deleteAllAndInsertAll(events: List<DateEvent>) {
         eventDao.deleteAllAndInsertAll(events)
     }

--- a/app/src/main/java/com/kippu/trace/model/DateEvent.kt
+++ b/app/src/main/java/com/kippu/trace/model/DateEvent.kt
@@ -8,6 +8,14 @@ enum class DisplayMode {
     ACCUMULATE  // 累计
 }
 
+enum class RepeatMode {
+    NONE,         // 不重复
+    YEARLY,       // 每年
+    MONTHLY,      // 每月
+    WEEKLY,       // 每周
+    CUSTOM_DAYS   // 自定义天数
+}
+
 @Entity(tableName = "date_events")
 data class DateEvent(
     @PrimaryKey(autoGenerate = true)
@@ -20,5 +28,16 @@ data class DateEvent(
     val backgroundUri: String? = null,
     val isPinned: Boolean = false,
     val maskOpacity: Float = 0.3f,
-    val position: Int = 0
+    val position: Int = 0,
+    // 倒数模式 - 自动重置
+    val repeatMode: RepeatMode = RepeatMode.NONE,
+    val repeatCustomDays: Int = 0,
+    // 累计模式 - 自定义纪念日
+    val customAnniversaryDays: Int = 0,       // N，0 表示不启用
+    // 累计模式 - 系统预设纪念日开关
+    val anniversaryYearEnabled: Boolean = false,
+    val anniversaryMonthEnabled: Boolean = false,
+    val anniversaryWeekEnabled: Boolean = false,
+    // 多纪念日同日触发时的合并文案
+    val anniversaryCombinedText: String = ""
 )

--- a/app/src/main/java/com/kippu/trace/model/DateEvent.kt
+++ b/app/src/main/java/com/kippu/trace/model/DateEvent.kt
@@ -1,5 +1,6 @@
 package com.kippu.trace.model
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -30,14 +31,21 @@ data class DateEvent(
     val maskOpacity: Float = 0.3f,
     val position: Int = 0,
     // 倒数模式 - 自动重置
+    @ColumnInfo(defaultValue = "NONE")
     val repeatMode: RepeatMode = RepeatMode.NONE,
+    @ColumnInfo(defaultValue = "0")
     val repeatCustomDays: Int = 0,
     // 累计模式 - 自定义纪念日
+    @ColumnInfo(defaultValue = "0")
     val customAnniversaryDays: Int = 0,       // N，0 表示不启用
     // 累计模式 - 系统预设纪念日开关
+    @ColumnInfo(defaultValue = "0")
     val anniversaryYearEnabled: Boolean = false,
+    @ColumnInfo(defaultValue = "0")
     val anniversaryMonthEnabled: Boolean = false,
+    @ColumnInfo(defaultValue = "0")
     val anniversaryWeekEnabled: Boolean = false,
     // 多纪念日同日触发时的合并文案
+    @ColumnInfo(defaultValue = "")
     val anniversaryCombinedText: String = ""
 )

--- a/app/src/main/java/com/kippu/trace/model/DateEvent.kt
+++ b/app/src/main/java/com/kippu/trace/model/DateEvent.kt
@@ -35,6 +35,8 @@ data class DateEvent(
     val repeatMode: RepeatMode = RepeatMode.NONE,
     @ColumnInfo(defaultValue = "0")
     val repeatCustomDays: Int = 0,
+    // 用户选择的原始重复日期；自动推进 targetDate 时保持不变。
+    val repeatAnchorDate: Long? = null,
     // 累计模式 - 自定义纪念日
     @ColumnInfo(defaultValue = "0")
     val customAnniversaryDays: Int = 0,       // N，0 表示不启用

--- a/app/src/main/java/com/kippu/trace/ui/components/AnniversaryConfigSection.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/AnniversaryConfigSection.kt
@@ -1,0 +1,361 @@
+package com.kippu.trace.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kippu.trace.R
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+
+@Composable
+fun AnniversaryConfigSection(
+    mode: DisplayMode,
+    repeatMode: RepeatMode,
+    onRepeatModeChange: (RepeatMode) -> Unit,
+    repeatCustomDays: Int,
+    onRepeatCustomDaysChange: (Int) -> Unit,
+    customAnniversaryDays: Int,
+    onCustomAnniversaryDaysChange: (Int) -> Unit,
+    anniversaryYearEnabled: Boolean,
+    onAnniversaryYearChange: (Boolean) -> Unit,
+    anniversaryMonthEnabled: Boolean,
+    onAnniversaryMonthChange: (Boolean) -> Unit,
+    anniversaryWeekEnabled: Boolean,
+    onAnniversaryWeekChange: (Boolean) -> Unit,
+    anniversaryCombinedText: String,
+    onAnniversaryCombinedTextChange: (String) -> Unit,
+) {
+    val enabledSwitchCount = listOf(
+        anniversaryYearEnabled, anniversaryMonthEnabled, anniversaryWeekEnabled
+    ).count { it }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        if (mode == DisplayMode.ACCUMULATE) {
+            Text(
+                text = stringResource(R.string.anniversary_section),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            CustomAnniversaryInput(
+                days = customAnniversaryDays,
+                onDaysChange = onCustomAnniversaryDaysChange
+            )
+
+            AnniversarySwitchRow(
+                label = stringResource(R.string.anniversary_year),
+                checked = anniversaryYearEnabled,
+                onCheckedChange = onAnniversaryYearChange
+            )
+            AnniversarySwitchRow(
+                label = stringResource(R.string.anniversary_month),
+                checked = anniversaryMonthEnabled,
+                onCheckedChange = onAnniversaryMonthChange
+            )
+            AnniversarySwitchRow(
+                label = stringResource(R.string.anniversary_week),
+                checked = anniversaryWeekEnabled,
+                onCheckedChange = onAnniversaryWeekChange
+            )
+
+            AnimatedVisibility(
+                visible = enabledSwitchCount >= 2 || (enabledSwitchCount >= 1 && customAnniversaryDays > 0),
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut()
+            ) {
+                CombinedTextInput(
+                    text = anniversaryCombinedText,
+                    onTextChange = onAnniversaryCombinedTextChange
+                )
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.repeat_section),
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.primary
+            )
+
+            RepeatModeSelector(
+                selected = repeatMode,
+                customDays = repeatCustomDays,
+                onModeSelected = onRepeatModeChange,
+                onCustomDaysChange = onRepeatCustomDaysChange
+            )
+        }
+    }
+}
+
+@Composable
+private fun CustomAnniversaryInput(days: Int, onDaysChange: (Int) -> Unit) {
+    val textState = rememberTextFieldState()
+
+    // 外部 → 内部同步
+    LaunchedEffect(days) {
+        val target = if (days > 0) days.toString() else ""
+        if (textState.text.toString() != target) {
+            textState.edit { replace(0, length, target) }
+        }
+    }
+    // 内部 → 外部同步
+    LaunchedEffect(textState) {
+        snapshotFlow { textState.text.toString() }
+            .collect { text ->
+                val filtered = text.filter { it.isDigit() }
+                onDaysChange(filtered.toIntOrNull() ?: 0)
+            }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = stringResource(R.string.anniversary_custom_label),
+            style = MaterialTheme.typography.titleSmall
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .width(80.dp)
+                    .height(40.dp)
+                    .background(
+                        MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.2f),
+                        RoundedCornerShape(10.dp)
+                    )
+                    .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(10.dp))
+                    .padding(horizontal = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                BasicTextField(
+                    state = textState,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    textStyle = TextStyle(
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    ),
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = stringResource(R.string.anniversary_custom_unit),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnniversarySwitchRow(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun CombinedTextInput(text: String, onTextChange: (String) -> Unit) {
+    val textState = rememberTextFieldState()
+
+    // 外部 → 内部同步
+    LaunchedEffect(text) {
+        if (textState.text.toString() != text) {
+            textState.edit { replace(0, length, text) }
+        }
+    }
+    // 内部 → 外部同步
+    LaunchedEffect(textState) {
+        snapshotFlow { textState.text.toString() }
+            .collect { onTextChange(it) }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(
+                MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.2f),
+                RoundedCornerShape(10.dp)
+            )
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(10.dp))
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        if (text.isEmpty()) {
+            Text(
+                text = stringResource(R.string.anniversary_combined_hint),
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        BasicTextField(
+            state = textState,
+            lineLimits = TextFieldLineLimits.SingleLine,
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            textStyle = TextStyle(fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface),
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun RepeatModeSelector(
+    selected: RepeatMode,
+    customDays: Int,
+    onModeSelected: (RepeatMode) -> Unit,
+    onCustomDaysChange: (Int) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        // 关闭
+        RepeatModeRow(
+            label = stringResource(R.string.repeat_none),
+            selected = selected == RepeatMode.NONE,
+            onClick = { onModeSelected(RepeatMode.NONE) }
+        )
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 4.dp),
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+        )
+
+        // 日历重复
+        RepeatModeRow(
+            label = stringResource(R.string.repeat_yearly),
+            selected = selected == RepeatMode.YEARLY,
+            onClick = { onModeSelected(RepeatMode.YEARLY) }
+        )
+        RepeatModeRow(
+            label = stringResource(R.string.repeat_monthly),
+            selected = selected == RepeatMode.MONTHLY,
+            onClick = { onModeSelected(RepeatMode.MONTHLY) }
+        )
+        RepeatModeRow(
+            label = stringResource(R.string.repeat_weekly),
+            selected = selected == RepeatMode.WEEKLY,
+            onClick = { onModeSelected(RepeatMode.WEEKLY) }
+        )
+
+        HorizontalDivider(
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 4.dp),
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
+        )
+
+        // 自定义
+        RepeatModeRow(
+            label = stringResource(R.string.repeat_custom),
+            selected = selected == RepeatMode.CUSTOM_DAYS,
+            onClick = { onModeSelected(RepeatMode.CUSTOM_DAYS) }
+        )
+
+        AnimatedVisibility(
+            visible = selected == RepeatMode.CUSTOM_DAYS,
+            enter = expandVertically() + fadeIn(),
+            exit = shrinkVertically() + fadeOut()
+        ) {
+            val textState = rememberTextFieldState()
+
+            // 外部 → 内部同步
+            LaunchedEffect(customDays) {
+                val target = if (customDays > 0) customDays.toString() else ""
+                if (textState.text.toString() != target) {
+                    textState.edit { replace(0, length, target) }
+                }
+            }
+            // 内部 → 外部同步
+            LaunchedEffect(textState) {
+                snapshotFlow { textState.text.toString() }
+                    .collect { text ->
+                        val filtered = text.filter { it.isDigit() }
+                        onCustomDaysChange(filtered.toIntOrNull() ?: 0)
+                    }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.End
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(40.dp)
+                        .background(
+                            MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.2f),
+                            RoundedCornerShape(10.dp)
+                        )
+                        .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(10.dp))
+                        .padding(horizontal = 8.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    BasicTextField(
+                        state = textState,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                        lineLimits = TextFieldLineLimits.SingleLine,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        textStyle = TextStyle(
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = stringResource(R.string.repeat_custom_unit),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RepeatModeRow(
+    label: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        RadioButton(selected = selected, onClick = onClick)
+    }
+}

--- a/app/src/main/java/com/kippu/trace/ui/components/CurrentDate.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/CurrentDate.kt
@@ -1,0 +1,29 @@
+package com.kippu.trace.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlinx.coroutines.delay
+
+@Composable
+fun rememberCurrentDate(zoneId: ZoneId = ZoneId.systemDefault()): LocalDate {
+    var currentDate by remember(zoneId) { mutableStateOf(LocalDate.now(zoneId)) }
+
+    LaunchedEffect(zoneId) {
+        while (true) {
+            val now = ZonedDateTime.now(zoneId)
+            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(zoneId)
+            delay(Duration.between(now, nextMidnight).toMillis().coerceAtLeast(1L))
+            currentDate = LocalDate.now(zoneId)
+        }
+    }
+
+    return currentDate
+}

--- a/app/src/main/java/com/kippu/trace/ui/components/DateConfigurationWizard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/DateConfigurationWizard.kt
@@ -1,0 +1,221 @@
+package com.kippu.trace.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.kippu.trace.R
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import com.kippu.trace.utils.EventDateUtils
+import com.kippu.trace.utils.isRepeatConfigurationValid
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DateConfigurationWizard(
+    initialConfiguration: EventDateConfiguration,
+    onConfirm: (EventDateConfiguration) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var draft by remember(initialConfiguration) { mutableStateOf(initialConfiguration) }
+    var step by remember(initialConfiguration) { mutableIntStateOf(0) }
+    val normalizedInitialDate = remember(initialConfiguration.targetDate) {
+        EventDateUtils.toUtcMillis(
+            EventDateUtils.fromStoredMillis(initialConfiguration.targetDate),
+        )
+    }
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = normalizedInitialDate,
+    )
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 0.dp,
+            modifier = Modifier
+                .widthIn(min = 320.dp, max = 480.dp)
+                .fillMaxWidth(0.85f)
+                .wrapContentHeight(),
+        ) {
+            if (step == 0) {
+                DateStep(
+                    onDismiss = onDismiss,
+                    onNext = {
+                        val selectedDate = datePickerState.selectedDateMillis ?: draft.targetDate
+                        draft = draft.selectDate(selectedDate)
+                        step = 1
+                    },
+                    datePicker = {
+                        DatePicker(
+                            state = datePickerState,
+                            title = null,
+                            headline = null,
+                            showModeToggle = false,
+                            colors = DatePickerDefaults.colors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                                dividerColor = Color.Transparent,
+                            ),
+                            modifier = it,
+                        )
+                    },
+                )
+            } else {
+                ConfigurationStep(
+                    draft = draft,
+                    onDraftChange = { draft = it },
+                    onConfirm = { onConfirm(draft) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DateStep(
+    onDismiss: () -> Unit,
+    onNext: () -> Unit,
+    datePicker: @Composable (Modifier) -> Unit,
+) {
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val pickerScale = (maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
+        Column(
+            modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.select_date),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .padding(start = 20.dp, end = 20.dp, bottom = 8.dp),
+            )
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                datePicker(Modifier.requiredWidth(360.dp).scale(pickerScale))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.cancel))
+                }
+                TextButton(onClick = onNext) {
+                    Text(stringResource(R.string.next))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfigurationStep(
+    draft: EventDateConfiguration,
+    onDraftChange: (EventDateConfiguration) -> Unit,
+    onConfirm: () -> Unit,
+) {
+    val isValid = isRepeatConfigurationValid(
+        draft.mode,
+        draft.repeatMode,
+        draft.repeatCustomDays,
+    )
+
+    Column(
+        modifier = Modifier.padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(
+                if (draft.mode == DisplayMode.COUNT_DOWN) {
+                    R.string.repeat_section
+                } else {
+                    R.string.anniversary_section
+                },
+            ),
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+        )
+        AnniversaryConfigSection(
+            mode = draft.mode,
+            repeatMode = draft.repeatMode,
+            onRepeatModeChange = { repeatMode ->
+                onDraftChange(
+                    draft.copy(
+                        repeatMode = repeatMode,
+                        repeatAnchorDate = if (repeatMode == RepeatMode.NONE) {
+                            null
+                        } else {
+                            draft.repeatAnchorDate ?: draft.targetDate
+                        },
+                    ),
+                )
+            },
+            repeatCustomDays = draft.repeatCustomDays,
+            onRepeatCustomDaysChange = { onDraftChange(draft.copy(repeatCustomDays = it)) },
+            customAnniversaryDays = draft.customAnniversaryDays,
+            onCustomAnniversaryDaysChange = {
+                onDraftChange(draft.copy(customAnniversaryDays = it))
+            },
+            anniversaryYearEnabled = draft.anniversaryYearEnabled,
+            onAnniversaryYearChange = {
+                onDraftChange(draft.copy(anniversaryYearEnabled = it))
+            },
+            anniversaryMonthEnabled = draft.anniversaryMonthEnabled,
+            onAnniversaryMonthChange = {
+                onDraftChange(draft.copy(anniversaryMonthEnabled = it))
+            },
+            anniversaryWeekEnabled = draft.anniversaryWeekEnabled,
+            onAnniversaryWeekChange = {
+                onDraftChange(draft.copy(anniversaryWeekEnabled = it))
+            },
+            anniversaryCombinedText = draft.anniversaryCombinedText,
+            onAnniversaryCombinedTextChange = {
+                onDraftChange(draft.copy(anniversaryCombinedText = it))
+            },
+        )
+        Button(
+            onClick = onConfirm,
+            enabled = isValid,
+            modifier = Modifier.fillMaxWidth().height(48.dp),
+            shape = RoundedCornerShape(14.dp),
+        ) {
+            Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}

--- a/app/src/main/java/com/kippu/trace/ui/components/EventDateConfiguration.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/EventDateConfiguration.kt
@@ -1,0 +1,69 @@
+package com.kippu.trace.ui.components
+
+import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import com.kippu.trace.utils.EventDateUtils
+import java.time.LocalDate
+import java.time.ZoneId
+
+data class EventDateConfiguration(
+    val targetDate: Long,
+    val mode: DisplayMode,
+    val repeatMode: RepeatMode,
+    val repeatCustomDays: Int,
+    val repeatAnchorDate: Long?,
+    val customAnniversaryDays: Int,
+    val anniversaryYearEnabled: Boolean,
+    val anniversaryMonthEnabled: Boolean,
+    val anniversaryWeekEnabled: Boolean,
+    val anniversaryCombinedText: String,
+)
+
+fun EventDateConfiguration.selectDate(
+    selectedDate: Long,
+    today: LocalDate = LocalDate.now(),
+    legacyZone: ZoneId = ZoneId.systemDefault(),
+): EventDateConfiguration {
+    val selectedMode = EventDateUtils.displayModeFor(selectedDate, today, legacyZone)
+    val dateChanged = EventDateUtils.fromStoredMillis(selectedDate, legacyZone) !=
+        EventDateUtils.fromStoredMillis(targetDate, legacyZone)
+    val selectedAnchor = when {
+        selectedMode != DisplayMode.COUNT_DOWN -> null
+        repeatMode == RepeatMode.NONE -> null
+        dateChanged -> selectedDate
+        else -> repeatAnchorDate ?: selectedDate
+    }
+    return copy(
+        targetDate = selectedDate,
+        mode = selectedMode,
+        repeatAnchorDate = selectedAnchor,
+    )
+}
+
+fun DateEvent.toDateConfiguration() = EventDateConfiguration(
+    targetDate = targetDate,
+    mode = mode,
+    repeatMode = repeatMode,
+    repeatCustomDays = repeatCustomDays,
+    repeatAnchorDate = repeatAnchorDate,
+    customAnniversaryDays = customAnniversaryDays,
+    anniversaryYearEnabled = anniversaryYearEnabled,
+    anniversaryMonthEnabled = anniversaryMonthEnabled,
+    anniversaryWeekEnabled = anniversaryWeekEnabled,
+    anniversaryCombinedText = anniversaryCombinedText,
+)
+
+fun DateEvent.withDateConfiguration(configuration: EventDateConfiguration) = copy(
+    targetDate = configuration.targetDate,
+    isFuture = configuration.mode == DisplayMode.COUNT_DOWN,
+    mode = configuration.mode,
+    repeatMode = configuration.repeatMode,
+    repeatCustomDays = configuration.repeatCustomDays,
+    repeatAnchorDate = configuration.repeatAnchorDate,
+    customAnniversaryDays = configuration.customAnniversaryDays,
+    anniversaryYearEnabled = configuration.anniversaryYearEnabled,
+    anniversaryMonthEnabled = configuration.anniversaryMonthEnabled,
+    anniversaryWeekEnabled = configuration.anniversaryWeekEnabled,
+    anniversaryCombinedText = configuration.anniversaryCombinedText,
+)

--- a/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.ui.theme.AnniversaryGold
+import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.TimeUtils
 import com.kippu.trace.utils.fadeRightEdge
@@ -39,9 +41,14 @@ fun NormalEventCard(
     val context = LocalContext.current
     val relativeTime = TimeUtils.getRelativeTime(event.targetDate)
     val timeDescription = TimeUtils.formatRelativeTime(context, relativeTime)
-    
+
     // 语义前缀
     val prefix = if (event.isFuture) stringResource(R.string.label_until) else stringResource(R.string.label_since)
+
+    // 纪念日检查（仅累计模式）
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+    val subtitleText = if (anniversary.isTriggered) anniversary.displayText() else "$prefix $timeDescription"
+    val subtitleColor = if (anniversary.isTriggered) AnniversaryGold else MaterialTheme.colorScheme.secondary
 
     val visualWidth = TextUtils.getVisualWidth(event.title)
     // 标题超过 8 个字或视觉宽度超过阈值时启用堆叠排版
@@ -80,11 +87,9 @@ fun NormalEventCard(
 
                 // 这个排版下的日期描述 移至左下角
                 Text(
-                    text = "$prefix $timeDescription",
+                    text = subtitleText,
                     modifier = Modifier.align(Alignment.BottomStart).padding(bottom = 6.dp),
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        color = MaterialTheme.colorScheme.secondary
-                    )
+                    style = MaterialTheme.typography.bodyMedium.copy(color = subtitleColor)
                 )
 
                 // 同理 天数在右下角
@@ -137,10 +142,8 @@ fun NormalEventCard(
                         )
                     )
                     Text(
-                        text = "$prefix $timeDescription",
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            color = MaterialTheme.colorScheme.secondary
-                        )
+                        text = subtitleText,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = subtitleColor)
                     )
                 }
 

--- a/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
@@ -18,12 +18,10 @@ import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.ui.theme.AnniversaryGold
 import com.kippu.trace.utils.AnniversaryUtils
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.TimeUtils
 import com.kippu.trace.utils.fadeRightEdge
-import com.kippu.trace.utils.rememberCurrentDate
-import java.time.Instant
-import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 @Composable
@@ -32,9 +30,7 @@ fun NormalEventCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val targetLocalDate = Instant.ofEpochMilli(event.targetDate)
-        .atZone(ZoneId.systemDefault())
-        .toLocalDate()
+    val targetLocalDate = EventDateUtils.fromStoredMillis(event.targetDate)
     val today = rememberCurrentDate()
     val daysTotal = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
     
@@ -46,7 +42,7 @@ fun NormalEventCard(
     val prefix = if (event.isFuture) stringResource(R.string.label_until) else stringResource(R.string.label_since)
 
     // 纪念日检查（仅累计模式）
-    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event, today)
     val subtitleText = if (anniversary.isTriggered) {
         anniversary.displayText(context.resources)
     } else {

--- a/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
@@ -47,7 +47,11 @@ fun NormalEventCard(
 
     // 纪念日检查（仅累计模式）
     val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
-    val subtitleText = if (anniversary.isTriggered) anniversary.displayText() else "$prefix $timeDescription"
+    val subtitleText = if (anniversary.isTriggered) {
+        anniversary.displayText(context.resources)
+    } else {
+        "$prefix $timeDescription"
+    }
     val subtitleColor = if (anniversary.isTriggered) AnniversaryGold else MaterialTheme.colorScheme.secondary
 
     val visualWidth = TextUtils.getVisualWidth(event.title)

--- a/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/NormalEventCard.kt
@@ -21,8 +21,8 @@ import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.TimeUtils
 import com.kippu.trace.utils.fadeRightEdge
+import com.kippu.trace.utils.rememberCurrentDate
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
@@ -35,7 +35,7 @@ fun NormalEventCard(
     val targetLocalDate = Instant.ofEpochMilli(event.targetDate)
         .atZone(ZoneId.systemDefault())
         .toLocalDate()
-    val today = LocalDate.now()
+    val today = rememberCurrentDate()
     val daysTotal = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
     
     val context = LocalContext.current

--- a/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
@@ -29,6 +29,8 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
+import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.fadeRightEdge
 import com.kippu.trace.utils.fadeLastLineEdge
@@ -49,6 +51,8 @@ fun PinnedEventCard(
         .toLocalDate()
     val today = LocalDate.now()
     val days = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
+
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
 
     Card(
         onClick = onClick,
@@ -149,10 +153,10 @@ fun PinnedEventCard(
                                 )
                             }
                             Text(
-                                text = targetLocalDate.toString(),
+                                text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
                                 style = MaterialTheme.typography.labelSmall.copy(
-                                    color = Color.White.copy(alpha = 0.7f),
-                                    fontWeight = FontWeight.Normal
+                                    color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.7f),
+                                    fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal
                                 )
                             )
                         }
@@ -204,10 +208,10 @@ fun PinnedEventCard(
                             }
 
                             Text(
-                                text = targetLocalDate.toString(),
+                                text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
                                 style = MaterialTheme.typography.labelSmall.copy(
-                                    color = Color.White.copy(alpha = 0.7f),
-                                    fontWeight = FontWeight.Normal
+                                    color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.7f),
+                                    fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal
                                 ),
                                 modifier = Modifier.offset(y = (-4).dp)
                             )
@@ -236,10 +240,10 @@ fun PinnedEventCard(
                                     )
                                 )
                                 Text(
-                                    text = targetLocalDate.toString(),
+                                    text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
                                     style = MaterialTheme.typography.labelMedium.copy(
-                                        color = Color.White.copy(alpha = 0.8f),
-                                        fontWeight = FontWeight.Normal
+                                        color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.8f),
+                                        fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal
                                     )
                                 )
                             }

--- a/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
@@ -36,8 +36,8 @@ import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.fadeRightEdge
 import com.kippu.trace.utils.fadeLastLineEdge
 import com.kippu.trace.utils.getLastLineHeightFraction
+import com.kippu.trace.utils.rememberCurrentDate
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
@@ -50,7 +50,7 @@ fun PinnedEventCard(
     val targetLocalDate = Instant.ofEpochMilli(event.targetDate)
         .atZone(ZoneId.systemDefault())
         .toLocalDate()
-    val today = LocalDate.now()
+    val today = rememberCurrentDate()
     val days = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
 
     val anniversary = AnniversaryUtils.checkAllAnniversaries(event)

--- a/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
@@ -53,6 +54,11 @@ fun PinnedEventCard(
     val days = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
 
     val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+    val anniversaryText = if (anniversary.isTriggered) {
+        anniversary.displayText(LocalContext.current.resources)
+    } else {
+        null
+    }
 
     Card(
         onClick = onClick,
@@ -153,7 +159,7 @@ fun PinnedEventCard(
                                 )
                             }
                             Text(
-                                text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
+                                text = anniversaryText ?: targetLocalDate.toString(),
                                 style = MaterialTheme.typography.labelSmall.copy(
                                     color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.7f),
                                     fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal
@@ -208,7 +214,7 @@ fun PinnedEventCard(
                             }
 
                             Text(
-                                text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
+                                text = anniversaryText ?: targetLocalDate.toString(),
                                 style = MaterialTheme.typography.labelSmall.copy(
                                     color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.7f),
                                     fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal
@@ -240,7 +246,7 @@ fun PinnedEventCard(
                                     )
                                 )
                                 Text(
-                                    text = if (anniversary.isTriggered) anniversary.displayText() else targetLocalDate.toString(),
+                                    text = anniversaryText ?: targetLocalDate.toString(),
                                     style = MaterialTheme.typography.labelMedium.copy(
                                         color = if (anniversary.isTriggered) AnniversaryGoldOnDark else Color.White.copy(alpha = 0.8f),
                                         fontWeight = if (anniversary.isTriggered) FontWeight.Bold else FontWeight.Normal

--- a/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
+++ b/app/src/main/java/com/kippu/trace/ui/components/PinnedEventCard.kt
@@ -32,13 +32,11 @@ import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
 import com.kippu.trace.utils.AnniversaryUtils
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.fadeRightEdge
 import com.kippu.trace.utils.fadeLastLineEdge
 import com.kippu.trace.utils.getLastLineHeightFraction
-import com.kippu.trace.utils.rememberCurrentDate
-import java.time.Instant
-import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 @Composable
@@ -47,13 +45,11 @@ fun PinnedEventCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val targetLocalDate = Instant.ofEpochMilli(event.targetDate)
-        .atZone(ZoneId.systemDefault())
-        .toLocalDate()
+    val targetLocalDate = EventDateUtils.fromStoredMillis(event.targetDate)
     val today = rememberCurrentDate()
     val days = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
 
-    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event, today)
     val anniversaryText = if (anniversary.isTriggered) {
         anniversary.displayText(LocalContext.current.resources)
     } else {

--- a/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.DriveFileRenameOutline
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.SaveAlt
@@ -57,8 +56,11 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
+import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.TimeUtils
+import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -602,6 +604,8 @@ fun EventDetailItem(
     val targetLocalDate = Instant.ofEpochMilli(event.targetDate).atZone(ZoneId.systemDefault()).toLocalDate()
     val days = ChronoUnit.DAYS.between(LocalDate.now(), targetLocalDate).let { if (it < 0) -it else it }
 
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+
     val animatedDays = remember { Animatable(0f) }
     var detailedTime by remember { mutableStateOf(TimeUtils.getDetailedTime(event.targetDate)) }
 
@@ -687,23 +691,7 @@ fun EventDetailItem(
             
             // 构造每9字换行且前缀紧跟末尾的标题（总长限35字）
             val annotatedTitle = remember(event.title, prefix) {
-                val displayTitle = if (event.title.length > 35) {
-                    event.title.take(32) + "..."
-                } else {
-                    event.title
-                }
-                
-                androidx.compose.ui.text.buildAnnotatedString {
-                    val chunks = displayTitle.chunked(9)
-                    chunks.forEachIndexed { index, chunk ->
-                        append(chunk)
-                        if (index < chunks.size - 1) append("\n")
-                    }
-                    append(" ")
-                    pushStyle(androidx.compose.ui.text.SpanStyle(color = Color.White.copy(alpha = 0.7f)))
-                    append(prefix)
-                    pop()
-                }
+                buildTitleWithPrefixAnnotatedString(event.title, prefix)
             }
 
             Text(
@@ -728,25 +716,54 @@ fun EventDetailItem(
                 else -> 120.sp
             }
 
-            Row(verticalAlignment = Alignment.Bottom) {
+            if (anniversary.isTriggered) {
+                // 纪念日大字展示
+                val anniversaryText = anniversary.displayText()
+                val anniversaryFontSize = when {
+                    anniversaryText.length >= 12 -> 28.sp
+                    anniversaryText.length >= 8 -> 36.sp
+                    anniversaryText.length >= 6 -> 48.sp
+                    else -> 64.sp
+                }
                 Text(
-                    text = animatedDays.value.toInt().toString(),
+                    text = anniversaryText,
                     style = MaterialTheme.typography.displayLarge.copy(
-                        fontSize = fontSize,
+                        fontSize = anniversaryFontSize,
                         fontWeight = FontWeight.Bold,
-                        color = Color.White
+                        color = AnniversaryGoldOnDark
+                    ),
+                    modifier = Modifier.padding(horizontal = 32.dp),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.anniversary_indicator),
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = AnniversaryGoldOnDark.copy(alpha = 0.8f),
+                        letterSpacing = 2.sp
+                    )
+                )
+            } else {
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Text(
+                        text = animatedDays.value.toInt().toString(),
+                        style = MaterialTheme.typography.displayLarge.copy(
+                            fontSize = fontSize,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White
+                        )
+                    )
+                }
+
+                val datePrefix = if (event.isFuture) stringResource(R.string.label_from) else stringResource(R.string.label_since_date)
+                Text(
+                    text = "$datePrefix $targetLocalDate",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Color.White.copy(alpha = 0.6f),
+                        letterSpacing = 2.sp
                     )
                 )
             }
-            
-            val datePrefix = if (event.isFuture) stringResource(R.string.label_from) else stringResource(R.string.label_since_date)
-            Text(
-                text = "$datePrefix $targetLocalDate",
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    color = Color.White.copy(alpha = 0.6f),
-                    letterSpacing = 2.sp
-                )
-            )
 
             Spacer(modifier = Modifier.height(8.dp))
 

--- a/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
@@ -718,7 +718,7 @@ fun EventDetailItem(
 
             if (anniversary.isTriggered) {
                 // 纪念日大字展示
-                val anniversaryText = anniversary.displayText()
+                val anniversaryText = anniversary.displayText(context.resources)
                 val anniversaryFontSize = when {
                     anniversaryText.length >= 12 -> 28.sp
                     anniversaryText.length >= 8 -> 36.sp

--- a/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
@@ -56,6 +56,7 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
 import com.kippu.trace.ui.components.AnniversaryConfigSection
 import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
 import com.kippu.trace.utils.AnniversaryUtils
@@ -494,6 +495,9 @@ fun DetailScreen(
                                             targetDate = selectedMillis,
                                             isFuture = isFuture,
                                             mode = if (isFuture) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE,
+                                            repeatAnchorDate = if (
+                                                pendingDateEvent?.repeatMode != RepeatMode.NONE
+                                            ) selectedMillis else null,
                                         )
                                     }
                                     datePickerStep = 1
@@ -528,7 +532,16 @@ fun DetailScreen(
                                 AnniversaryConfigSection(
                                     mode = pendingEvent.mode,
                                     repeatMode = pendingEvent.repeatMode,
-                                    onRepeatModeChange = { pendingDateEvent = pendingEvent.copy(repeatMode = it) },
+                                    onRepeatModeChange = { repeatMode ->
+                                        pendingDateEvent = pendingEvent.copy(
+                                            repeatMode = repeatMode,
+                                            repeatAnchorDate = if (repeatMode == RepeatMode.NONE) {
+                                                null
+                                            } else {
+                                                pendingEvent.repeatAnchorDate ?: pendingEvent.targetDate
+                                            },
+                                        )
+                                    },
                                     repeatCustomDays = pendingEvent.repeatCustomDays,
                                     onRepeatCustomDaysChange = { pendingDateEvent = pendingEvent.copy(repeatCustomDays = it) },
                                     customAnniversaryDays = pendingEvent.customAnniversaryDays,

--- a/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
@@ -56,19 +56,18 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
-import com.kippu.trace.model.RepeatMode
-import com.kippu.trace.ui.components.AnniversaryConfigSection
+import com.kippu.trace.ui.components.DateConfigurationWizard
+import com.kippu.trace.ui.components.rememberCurrentDate
+import com.kippu.trace.ui.components.toDateConfiguration
+import com.kippu.trace.ui.components.withDateConfiguration
 import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
 import com.kippu.trace.utils.AnniversaryUtils
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.TimeUtils
 import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
-import com.kippu.trace.utils.isRepeatConfigurationValid
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.math.abs
@@ -91,8 +90,6 @@ fun DetailScreen(
     
     // 日期选择
     var showDatePicker by remember { mutableStateOf(false) }
-    val datePickerState = rememberDatePickerState()
-    var datePickerStep by remember { mutableIntStateOf(0) }
     var pendingDateEvent by remember { mutableStateOf<DateEvent?>(null) }
 
     // 标题编辑
@@ -350,9 +347,6 @@ fun DetailScreen(
                                     val realIndex = pagerState.currentPage % events.size
                                     events.getOrNull(realIndex)?.let { currentEvent ->
                                         pendingDateEvent = currentEvent
-                                        datePickerState.selectedDateMillis = currentEvent.targetDate
-                                        datePickerState.displayedMonthMillis = currentEvent.targetDate
-                                        datePickerStep = 0
                                         showDatePicker = true
                                     }
                                 }
@@ -401,177 +395,20 @@ fun DetailScreen(
             )
         }
 
-        // 小一些的日期选择器
         if (showDatePicker) {
-            androidx.compose.ui.window.Dialog(
-                onDismissRequest = {
-                    showDatePicker = false
-                    pendingDateEvent = null
-                },
-                properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(28.dp),
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 0.dp,
-                    modifier = Modifier
-                        // 手机上默认 320dp，在大屏（如 Pad）下最高可扩展至 480dp
-                        .widthIn(min = 320.dp, max = 480.dp)
-                        .fillMaxWidth(0.85f)
-                        .wrapContentHeight()
-                ) {
-                    if (datePickerStep == 0) {
-                        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                            val scope = this
-                            // 根据容器实际宽度计算缩放比例。360dp 是 DatePicker 完整显示所需的理想宽度
-                            val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
-                        
-                            Column(
-                                modifier = Modifier.padding(top = 20.dp, bottom = 0.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                            Text(
-                                text = stringResource(R.string.select_date),
-                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                                modifier = Modifier
-                                    .align(Alignment.Start)
-                                    .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
-                            )
-                            
-                            Box(
-                                modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                // 通过局部覆盖 Typography 来拉开星期与日期之间的间隙
-                                MaterialTheme(
-                                    colorScheme = MaterialTheme.colorScheme,
-                                    shapes = MaterialTheme.shapes,
-                                    typography = MaterialTheme.typography.copy(
-                                        labelLarge = MaterialTheme.typography.labelLarge.copy(
-                                            fontSize = 12.sp,
-                                            lineHeight = 48.sp
-                                        )
-                                    )
-                                ) {
-                                    DatePicker(
-                                        state = datePickerState,
-                                        title = null,
-                                        headline = null,
-                                        showModeToggle = false,
-                                        colors = DatePickerDefaults.colors(
-                                            containerColor = MaterialTheme.colorScheme.surface,
-                                            dividerColor = Color.Transparent
-                                        ),
-                                        modifier = Modifier
-                                            // 强制指定 DatePicker 宽度为 360dp 以防止其内部日期列丢失
-                                            .requiredWidth(360.dp)
-                                            // 缩放以适配外部 Surface 容器
-                                            .scale(scale)
-                                            // 向上偏移，减少与标题的间距
-                                            .offset(y = (-12).dp)
-                                    )
-                                }
-                            }
-
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp)
-                                    // 向上偏移，减少与日历底部的间距
-                                    .offset(y = (-20).dp),
-                                horizontalArrangement = Arrangement.End
-                            ) {
-                                TextButton(onClick = {
-                                    showDatePicker = false
-                                    pendingDateEvent = null
-                                }) {
-                                    Text(stringResource(R.string.cancel))
-                                }
-                                TextButton(onClick = {
-                                    val selectedMillis = datePickerState.selectedDateMillis
-                                    if (selectedMillis != null) {
-                                        val isFuture = selectedMillis > System.currentTimeMillis()
-                                        pendingDateEvent = pendingDateEvent?.copy(
-                                            targetDate = selectedMillis,
-                                            isFuture = isFuture,
-                                            mode = if (isFuture) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE,
-                                            repeatAnchorDate = if (
-                                                pendingDateEvent?.repeatMode != RepeatMode.NONE
-                                            ) selectedMillis else null,
-                                        )
-                                    }
-                                    datePickerStep = 1
-                                }) {
-                                    Text(stringResource(R.string.next))
-                                }
-                            }
-                        }
-                    }
-                    } else {
-                        pendingDateEvent?.let { pendingEvent ->
-                            val isRepeatValid = isRepeatConfigurationValid(
-                                pendingEvent.mode,
-                                pendingEvent.repeatMode,
-                                pendingEvent.repeatCustomDays,
-                            )
-                            Column(
-                                modifier = Modifier.padding(24.dp),
-                                verticalArrangement = Arrangement.spacedBy(16.dp),
-                            ) {
-                                Text(
-                                    text = stringResource(
-                                        if (pendingEvent.mode == DisplayMode.COUNT_DOWN) {
-                                            R.string.repeat_section
-                                        } else {
-                                            R.string.anniversary_section
-                                        }
-                                    ),
-                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                                )
-
-                                AnniversaryConfigSection(
-                                    mode = pendingEvent.mode,
-                                    repeatMode = pendingEvent.repeatMode,
-                                    onRepeatModeChange = { repeatMode ->
-                                        pendingDateEvent = pendingEvent.copy(
-                                            repeatMode = repeatMode,
-                                            repeatAnchorDate = if (repeatMode == RepeatMode.NONE) {
-                                                null
-                                            } else {
-                                                pendingEvent.repeatAnchorDate ?: pendingEvent.targetDate
-                                            },
-                                        )
-                                    },
-                                    repeatCustomDays = pendingEvent.repeatCustomDays,
-                                    onRepeatCustomDaysChange = { pendingDateEvent = pendingEvent.copy(repeatCustomDays = it) },
-                                    customAnniversaryDays = pendingEvent.customAnniversaryDays,
-                                    onCustomAnniversaryDaysChange = { pendingDateEvent = pendingEvent.copy(customAnniversaryDays = it) },
-                                    anniversaryYearEnabled = pendingEvent.anniversaryYearEnabled,
-                                    onAnniversaryYearChange = { pendingDateEvent = pendingEvent.copy(anniversaryYearEnabled = it) },
-                                    anniversaryMonthEnabled = pendingEvent.anniversaryMonthEnabled,
-                                    onAnniversaryMonthChange = { pendingDateEvent = pendingEvent.copy(anniversaryMonthEnabled = it) },
-                                    anniversaryWeekEnabled = pendingEvent.anniversaryWeekEnabled,
-                                    onAnniversaryWeekChange = { pendingDateEvent = pendingEvent.copy(anniversaryWeekEnabled = it) },
-                                    anniversaryCombinedText = pendingEvent.anniversaryCombinedText,
-                                    onAnniversaryCombinedTextChange = { pendingDateEvent = pendingEvent.copy(anniversaryCombinedText = it) },
-                                )
-
-                                Button(
-                                    onClick = {
-                                        onUpdateEvent(pendingEvent)
-                                        showDatePicker = false
-                                        pendingDateEvent = null
-                                    },
-                                    enabled = isRepeatValid,
-                                    modifier = Modifier.fillMaxWidth().height(48.dp),
-                                    shape = RoundedCornerShape(14.dp),
-                                ) {
-                                    Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
-                                }
-                            }
-                        }
-                    }
-                }
+            pendingDateEvent?.let { pendingEvent ->
+                DateConfigurationWizard(
+                    initialConfiguration = pendingEvent.toDateConfiguration(),
+                    onConfirm = { configuration ->
+                        onUpdateEvent(pendingEvent.withDateConfiguration(configuration))
+                        showDatePicker = false
+                        pendingDateEvent = null
+                    },
+                    onDismiss = {
+                        showDatePicker = false
+                        pendingDateEvent = null
+                    },
+                )
             }
         }
     }
@@ -682,10 +519,11 @@ fun EventDetailItem(
 ) {
     val context = LocalContext.current
     val graphicsLayer = rememberGraphicsLayer()
-    val targetLocalDate = Instant.ofEpochMilli(event.targetDate).atZone(ZoneId.systemDefault()).toLocalDate()
-    val days = ChronoUnit.DAYS.between(LocalDate.now(), targetLocalDate).let { if (it < 0) -it else it }
+    val targetLocalDate = EventDateUtils.fromStoredMillis(event.targetDate)
+    val today = rememberCurrentDate()
+    val days = ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
 
-    val anniversary = AnniversaryUtils.checkAllAnniversaries(event)
+    val anniversary = AnniversaryUtils.checkAllAnniversaries(event, today)
 
     val animatedDays = remember { Animatable(0f) }
     var detailedTime by remember { mutableStateOf(TimeUtils.getDetailedTime(event.targetDate)) }

--- a/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/DetailScreen.kt
@@ -56,11 +56,13 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.ui.components.AnniversaryConfigSection
 import com.kippu.trace.ui.theme.AnniversaryGoldOnDark
 import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.TimeUtils
 import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
+import com.kippu.trace.utils.isRepeatConfigurationValid
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -89,6 +91,8 @@ fun DetailScreen(
     // 日期选择
     var showDatePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
+    var datePickerStep by remember { mutableIntStateOf(0) }
+    var pendingDateEvent by remember { mutableStateOf<DateEvent?>(null) }
 
     // 标题编辑
     var showTitleEditDialog by remember { mutableStateOf(false) }
@@ -340,9 +344,16 @@ fun DetailScreen(
                                 title = stringResource(R.string.adjust_date),
                                 subtitle = stringResource(R.string.adjust_date_subtitle),
                                 shape = RoundedCornerShape(bottomStart = 28.dp, bottomEnd = 28.dp),
-                                onClick = { 
+                                onClick = {
                                     showBottomSheet = false
-                                    showDatePicker = true
+                                    val realIndex = pagerState.currentPage % events.size
+                                    events.getOrNull(realIndex)?.let { currentEvent ->
+                                        pendingDateEvent = currentEvent
+                                        datePickerState.selectedDateMillis = currentEvent.targetDate
+                                        datePickerState.displayedMonthMillis = currentEvent.targetDate
+                                        datePickerStep = 0
+                                        showDatePicker = true
+                                    }
                                 }
                             )
                         }
@@ -392,7 +403,10 @@ fun DetailScreen(
         // 小一些的日期选择器
         if (showDatePicker) {
             androidx.compose.ui.window.Dialog(
-                onDismissRequest = { showDatePicker = false },
+                onDismissRequest = {
+                    showDatePicker = false
+                    pendingDateEvent = null
+                },
                 properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false)
             ) {
                 Surface(
@@ -405,15 +419,16 @@ fun DetailScreen(
                         .fillMaxWidth(0.85f)
                         .wrapContentHeight()
                 ) {
-                    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                        val scope = this
-                        // 根据容器实际宽度计算缩放比例。360dp 是 DatePicker 完整显示所需的理想宽度
-                        val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
+                    if (datePickerStep == 0) {
+                        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                            val scope = this
+                            // 根据容器实际宽度计算缩放比例。360dp 是 DatePicker 完整显示所需的理想宽度
+                            val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
                         
-                        Column(
-                            modifier = Modifier.padding(top = 20.dp, bottom = 0.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
+                            Column(
+                                modifier = Modifier.padding(top = 20.dp, bottom = 0.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
                             Text(
                                 text = stringResource(R.string.select_date),
                                 style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
@@ -465,27 +480,80 @@ fun DetailScreen(
                                     .offset(y = (-20).dp),
                                 horizontalArrangement = Arrangement.End
                             ) {
-                                TextButton(onClick = { showDatePicker = false }) {
+                                TextButton(onClick = {
+                                    showDatePicker = false
+                                    pendingDateEvent = null
+                                }) {
                                     Text(stringResource(R.string.cancel))
                                 }
                                 TextButton(onClick = {
                                     val selectedMillis = datePickerState.selectedDateMillis
                                     if (selectedMillis != null) {
-                                        val realIndex = pagerState.currentPage % events.size
-                                        val currentEvent = events.getOrNull(realIndex)
-                                        if (currentEvent != null) {
-                                            val isFuture = selectedMillis > System.currentTimeMillis()
-                                            val newMode = if (isFuture) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
-                                            onUpdateEvent(currentEvent.copy(
-                                                targetDate = selectedMillis,
-                                                isFuture = isFuture,
-                                                mode = newMode
-                                            ))
-                                        }
+                                        val isFuture = selectedMillis > System.currentTimeMillis()
+                                        pendingDateEvent = pendingDateEvent?.copy(
+                                            targetDate = selectedMillis,
+                                            isFuture = isFuture,
+                                            mode = if (isFuture) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE,
+                                        )
                                     }
-                                    showDatePicker = false
+                                    datePickerStep = 1
                                 }) {
-                                    Text(stringResource(R.string.confirm))
+                                    Text(stringResource(R.string.next))
+                                }
+                            }
+                        }
+                    }
+                    } else {
+                        pendingDateEvent?.let { pendingEvent ->
+                            val isRepeatValid = isRepeatConfigurationValid(
+                                pendingEvent.mode,
+                                pendingEvent.repeatMode,
+                                pendingEvent.repeatCustomDays,
+                            )
+                            Column(
+                                modifier = Modifier.padding(24.dp),
+                                verticalArrangement = Arrangement.spacedBy(16.dp),
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        if (pendingEvent.mode == DisplayMode.COUNT_DOWN) {
+                                            R.string.repeat_section
+                                        } else {
+                                            R.string.anniversary_section
+                                        }
+                                    ),
+                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                                )
+
+                                AnniversaryConfigSection(
+                                    mode = pendingEvent.mode,
+                                    repeatMode = pendingEvent.repeatMode,
+                                    onRepeatModeChange = { pendingDateEvent = pendingEvent.copy(repeatMode = it) },
+                                    repeatCustomDays = pendingEvent.repeatCustomDays,
+                                    onRepeatCustomDaysChange = { pendingDateEvent = pendingEvent.copy(repeatCustomDays = it) },
+                                    customAnniversaryDays = pendingEvent.customAnniversaryDays,
+                                    onCustomAnniversaryDaysChange = { pendingDateEvent = pendingEvent.copy(customAnniversaryDays = it) },
+                                    anniversaryYearEnabled = pendingEvent.anniversaryYearEnabled,
+                                    onAnniversaryYearChange = { pendingDateEvent = pendingEvent.copy(anniversaryYearEnabled = it) },
+                                    anniversaryMonthEnabled = pendingEvent.anniversaryMonthEnabled,
+                                    onAnniversaryMonthChange = { pendingDateEvent = pendingEvent.copy(anniversaryMonthEnabled = it) },
+                                    anniversaryWeekEnabled = pendingEvent.anniversaryWeekEnabled,
+                                    onAnniversaryWeekChange = { pendingDateEvent = pendingEvent.copy(anniversaryWeekEnabled = it) },
+                                    anniversaryCombinedText = pendingEvent.anniversaryCombinedText,
+                                    onAnniversaryCombinedTextChange = { pendingDateEvent = pendingEvent.copy(anniversaryCombinedText = it) },
+                                )
+
+                                Button(
+                                    onClick = {
+                                        onUpdateEvent(pendingEvent)
+                                        showDatePicker = false
+                                        pendingDateEvent = null
+                                    },
+                                    enabled = isRepeatValid,
+                                    modifier = Modifier.fillMaxWidth().height(48.dp),
+                                    shape = RoundedCornerShape(14.dp),
+                                ) {
+                                    Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
                                 }
                             }
                         }

--- a/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
@@ -122,6 +122,7 @@ fun EditorScreen(
 
     if (showDatePicker.value) {
         val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
+        var datePickerStep by remember { mutableIntStateOf(0) }  // 0=日期选择 1=纪念日/重置设置
 
         Dialog(
             onDismissRequest = { showDatePicker.value = false },
@@ -132,64 +133,102 @@ fun EditorScreen(
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 0.dp,
                 modifier = Modifier
-                    // 手机上默认 320dp，在大屏（如 Pad）下最高可扩展至 480dp
                     .widthIn(min = 320.dp, max = 480.dp)
                     .fillMaxWidth(0.85f)
                     .wrapContentHeight()
             ) {
-                BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                    val scope = this
-                    // 根据容器实际宽度计算缩放比例。360dp 是 DatePicker 完整显示所需的理想宽度。
-                    val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
-                    
+                if (datePickerStep == 0) {
+                    // 第一步：选择日期
+                    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                        val scope = this
+                        val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
+
+                        Column(
+                            modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = stringResource(R.string.select_date),
+                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                                modifier = Modifier
+                                    .align(Alignment.Start)
+                                    .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
+                            )
+
+                            Box(
+                                modifier = Modifier.fillMaxWidth(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                DatePicker(
+                                    state = datePickerState,
+                                    title = null,
+                                    headline = null,
+                                    showModeToggle = false,
+                                    colors = DatePickerDefaults.colors(
+                                        containerColor = MaterialTheme.colorScheme.surface,
+                                        dividerColor = Color.Transparent
+                                    ),
+                                    modifier = Modifier
+                                        .requiredWidth(360.dp)
+                                        .scale(scale)
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                                horizontalArrangement = Arrangement.End
+                            ) {
+                                TextButton(onClick = { showDatePicker.value = false }) {
+                                    Text(stringResource(R.string.cancel))
+                                }
+                                TextButton(onClick = {
+                                    datePickerState.selectedDateMillis?.let { selectedDate = it }
+                                    datePickerStep = 1
+                                }) {
+                                    Text(stringResource(R.string.next))
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // 第二步：Reset / Anniversary 设置
                     Column(
-                        modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                        modifier = Modifier.padding(24.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         Text(
-                            text = stringResource(R.string.select_date),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                            modifier = Modifier
-                                .align(Alignment.Start)
-                                .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
+                            text = stringResource(
+                                if (mode == DisplayMode.COUNT_DOWN) R.string.repeat_section else R.string.anniversary_section
+                            ),
+                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
                         )
 
-                        Box(
-                            modifier = Modifier.fillMaxWidth(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            DatePicker(
-                                state = datePickerState,
-                                title = null,
-                                headline = null,
-                                showModeToggle = false,
-                                colors = DatePickerDefaults.colors(
-                                    containerColor = MaterialTheme.colorScheme.surface,
-                                    dividerColor = Color.Transparent
-                                ),
-                                modifier = Modifier
-                                    // 强制指定 DatePicker 宽度为 360dp 以防止其内部日期列丢失
-                                    .requiredWidth(360.dp)
-                                    // 缩放以适配外部 Surface 容器
-                                    .scale(scale)
-                            )
-                        }
+                        AnniversaryConfigSection(
+                            mode = mode,
+                            repeatMode = repeatMode,
+                            onRepeatModeChange = { repeatMode = it },
+                            repeatCustomDays = repeatCustomDays,
+                            onRepeatCustomDaysChange = { repeatCustomDays = it },
+                            customAnniversaryDays = customAnniversaryDays,
+                            onCustomAnniversaryDaysChange = { customAnniversaryDays = it },
+                            anniversaryYearEnabled = anniversaryYearEnabled,
+                            onAnniversaryYearChange = { anniversaryYearEnabled = it },
+                            anniversaryMonthEnabled = anniversaryMonthEnabled,
+                            onAnniversaryMonthChange = { anniversaryMonthEnabled = it },
+                            anniversaryWeekEnabled = anniversaryWeekEnabled,
+                            onAnniversaryWeekChange = { anniversaryWeekEnabled = it },
+                            anniversaryCombinedText = anniversaryCombinedText,
+                            onAnniversaryCombinedTextChange = { anniversaryCombinedText = it },
+                        )
 
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                            horizontalArrangement = Arrangement.End
+                        Button(
+                            onClick = { showDatePicker.value = false },
+                            modifier = Modifier.fillMaxWidth().height(48.dp),
+                            shape = RoundedCornerShape(14.dp)
                         ) {
-                            TextButton(onClick = { showDatePicker.value = false }) {
-                                Text(stringResource(R.string.cancel))
-                            }
-                            TextButton(onClick = {
-                                datePickerState.selectedDateMillis?.let { selectedDate = it }
-                                showDatePicker.value = false
-                            }) {
-                                Text(stringResource(R.string.confirm))
-                            }
+                            Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
                         }
                     }
                 }
@@ -327,24 +366,6 @@ fun EditorScreen(
                 ModeSwitcher(
                     selectedMode = mode,
                     onModeSelected = { mode = it }
-                )
-
-                AnniversaryConfigSection(
-                    mode = mode,
-                    repeatMode = repeatMode,
-                    onRepeatModeChange = { repeatMode = it },
-                    repeatCustomDays = repeatCustomDays,
-                    onRepeatCustomDaysChange = { repeatCustomDays = it },
-                    customAnniversaryDays = customAnniversaryDays,
-                    onCustomAnniversaryDaysChange = { customAnniversaryDays = it },
-                    anniversaryYearEnabled = anniversaryYearEnabled,
-                    onAnniversaryYearChange = { anniversaryYearEnabled = it },
-                    anniversaryMonthEnabled = anniversaryMonthEnabled,
-                    onAnniversaryMonthChange = { anniversaryMonthEnabled = it },
-                    anniversaryWeekEnabled = anniversaryWeekEnabled,
-                    onAnniversaryWeekChange = { anniversaryWeekEnabled = it },
-                    anniversaryCombinedText = anniversaryCombinedText,
-                    onAnniversaryCombinedTextChange = { anniversaryCombinedText = it },
                 )
             }
 

--- a/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
@@ -46,10 +46,13 @@ import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import com.kippu.trace.ui.components.AnniversaryConfigSection
 import com.kippu.trace.ui.components.PinnedEventCard
 import com.kippu.trace.ui.theme.KIPPU_TraceTheme
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.TextUtils
+import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -73,6 +76,15 @@ fun EditorScreen(
     var maskOpacity by remember { mutableFloatStateOf(0.4f) }
     val showDatePicker = remember { mutableStateOf(false) }
     var mode by remember { mutableStateOf(DisplayMode.COUNT_DOWN) }
+    // 倒数模式 - 重复
+    var repeatMode by remember { mutableStateOf(RepeatMode.NONE) }
+    var repeatCustomDays by remember { mutableIntStateOf(0) }
+    // 累计模式 - 纪念日
+    var customAnniversaryDays by remember { mutableIntStateOf(0) }
+    var anniversaryYearEnabled by remember { mutableStateOf(false) }
+    var anniversaryMonthEnabled by remember { mutableStateOf(false) }
+    var anniversaryWeekEnabled by remember { mutableStateOf(false) }
+    var anniversaryCombinedText by remember { mutableStateOf("") }
 
     val scrollState = rememberScrollState()
 
@@ -203,7 +215,14 @@ fun EditorScreen(
                             mode = mode,
                             isPinned = isPinned,
                             backgroundUri = backgroundUri,
-                            maskOpacity = maskOpacity
+                            maskOpacity = maskOpacity,
+                            repeatMode = repeatMode,
+                            repeatCustomDays = repeatCustomDays,
+                            customAnniversaryDays = customAnniversaryDays,
+                            anniversaryYearEnabled = anniversaryYearEnabled,
+                            anniversaryMonthEnabled = anniversaryMonthEnabled,
+                            anniversaryWeekEnabled = anniversaryWeekEnabled,
+                            anniversaryCombinedText = anniversaryCombinedText,
                         ))
                     }) {
                         Icon(painter = rememberVectorPainter(Icons.Default.Check), contentDescription = "Save", tint = MaterialTheme.colorScheme.primary)
@@ -308,6 +327,24 @@ fun EditorScreen(
                 ModeSwitcher(
                     selectedMode = mode,
                     onModeSelected = { mode = it }
+                )
+
+                AnniversaryConfigSection(
+                    mode = mode,
+                    repeatMode = repeatMode,
+                    onRepeatModeChange = { repeatMode = it },
+                    repeatCustomDays = repeatCustomDays,
+                    onRepeatCustomDaysChange = { repeatCustomDays = it },
+                    customAnniversaryDays = customAnniversaryDays,
+                    onCustomAnniversaryDaysChange = { customAnniversaryDays = it },
+                    anniversaryYearEnabled = anniversaryYearEnabled,
+                    onAnniversaryYearChange = { anniversaryYearEnabled = it },
+                    anniversaryMonthEnabled = anniversaryMonthEnabled,
+                    onAnniversaryMonthChange = { anniversaryMonthEnabled = it },
+                    anniversaryWeekEnabled = anniversaryWeekEnabled,
+                    onAnniversaryWeekChange = { anniversaryWeekEnabled = it },
+                    anniversaryCombinedText = anniversaryCombinedText,
+                    onAnniversaryCombinedTextChange = { anniversaryCombinedText = it },
                 )
             }
 
@@ -501,23 +538,7 @@ fun FullScreenPreviewContent(title: String, days: String, imageUri: String?, opa
             
             // 构造每9字换行且前缀紧跟末尾的标题（同步 DetailScreen 逻辑）
             val annotatedTitle = remember(title, prefix) {
-                val displayTitle = if (title.length > 35) {
-                    title.take(32) + "..."
-                } else {
-                    title
-                }
-                
-                androidx.compose.ui.text.buildAnnotatedString {
-                    val chunks = displayTitle.chunked(9)
-                    chunks.forEachIndexed { index, chunk ->
-                        append(chunk)
-                        if (index < chunks.size - 1) append("\n")
-                    }
-                    append(" ")
-                    pushStyle(androidx.compose.ui.text.SpanStyle(color = Color.White.copy(alpha = 0.7f)))
-                    append(prefix)
-                    pop()
-                }
+                buildTitleWithPrefixAnnotatedString(title, prefix)
             }
 
             Text(

--- a/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -40,23 +39,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.model.RepeatMode
-import com.kippu.trace.ui.components.AnniversaryConfigSection
+import com.kippu.trace.ui.components.DateConfigurationWizard
+import com.kippu.trace.ui.components.EventDateConfiguration
 import com.kippu.trace.ui.components.PinnedEventCard
 import com.kippu.trace.ui.theme.KIPPU_TraceTheme
 import com.kippu.trace.utils.FileUtils
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
 import com.kippu.trace.utils.isRepeatConfigurationValid
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
@@ -71,7 +68,9 @@ fun EditorScreen(
     // 使用新版 TextFieldState
     val titleState = rememberTextFieldState("")
     
-    var selectedDate by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    var selectedDate by remember {
+        mutableLongStateOf(EventDateUtils.toUtcMillis(LocalDate.now()))
+    }
     var backgroundUri by remember { mutableStateOf<String?>(null) }
     var isPinned by remember { mutableStateOf(false) }
     var maskOpacity by remember { mutableFloatStateOf(0.4f) }
@@ -101,7 +100,7 @@ fun EditorScreen(
     }
 
     val targetLocalDate = remember(selectedDate) {
-        Instant.ofEpochMilli(selectedDate).atZone(ZoneId.systemDefault()).toLocalDate()
+        EventDateUtils.fromStoredMillis(selectedDate)
     }
     
     val days = remember(targetLocalDate) {
@@ -115,7 +114,7 @@ fun EditorScreen(
     }
     
     LaunchedEffect(selectedDate) {
-        mode = if (selectedDate > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
+        mode = EventDateUtils.displayModeFor(selectedDate)
     }
 
     val untitledText = stringResource(R.string.untitled)
@@ -123,120 +122,33 @@ fun EditorScreen(
     val isRepeatValid = isRepeatConfigurationValid(mode, repeatMode, repeatCustomDays)
 
     if (showDatePicker.value) {
-        val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
-        var datePickerStep by remember { mutableIntStateOf(0) }  // 0=日期选择 1=纪念日/重置设置
-
-        Dialog(
-            onDismissRequest = { showDatePicker.value = false },
-            properties = DialogProperties(usePlatformDefaultWidth = false)
-        ) {
-            Surface(
-                shape = RoundedCornerShape(28.dp),
-                color = MaterialTheme.colorScheme.surface,
-                tonalElevation = 0.dp,
-                modifier = Modifier
-                    .widthIn(min = 320.dp, max = 480.dp)
-                    .fillMaxWidth(0.85f)
-                    .wrapContentHeight()
-            ) {
-                if (datePickerStep == 0) {
-                    // 第一步：选择日期
-                    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                        val scope = this
-                        val scale = (scope.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
-
-                        Column(
-                            modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Text(
-                                text = stringResource(R.string.select_date),
-                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                                modifier = Modifier
-                                    .align(Alignment.Start)
-                                    .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
-                            )
-
-                            Box(
-                                modifier = Modifier.fillMaxWidth(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                DatePicker(
-                                    state = datePickerState,
-                                    title = null,
-                                    headline = null,
-                                    showModeToggle = false,
-                                    colors = DatePickerDefaults.colors(
-                                        containerColor = MaterialTheme.colorScheme.surface,
-                                        dividerColor = Color.Transparent
-                                    ),
-                                    modifier = Modifier
-                                        .requiredWidth(360.dp)
-                                        .scale(scale)
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            Row(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                                horizontalArrangement = Arrangement.End
-                            ) {
-                                TextButton(onClick = { showDatePicker.value = false }) {
-                                    Text(stringResource(R.string.cancel))
-                                }
-                                TextButton(onClick = {
-                                    datePickerState.selectedDateMillis?.let { selectedDate = it }
-                                    datePickerStep = 1
-                                }) {
-                                    Text(stringResource(R.string.next))
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // 第二步：Reset / Anniversary 设置
-                    Column(
-                        modifier = Modifier.padding(24.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        Text(
-                            text = stringResource(
-                                if (mode == DisplayMode.COUNT_DOWN) R.string.repeat_section else R.string.anniversary_section
-                            ),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                        )
-
-                        AnniversaryConfigSection(
-                            mode = mode,
-                            repeatMode = repeatMode,
-                            onRepeatModeChange = { repeatMode = it },
-                            repeatCustomDays = repeatCustomDays,
-                            onRepeatCustomDaysChange = { repeatCustomDays = it },
-                            customAnniversaryDays = customAnniversaryDays,
-                            onCustomAnniversaryDaysChange = { customAnniversaryDays = it },
-                            anniversaryYearEnabled = anniversaryYearEnabled,
-                            onAnniversaryYearChange = { anniversaryYearEnabled = it },
-                            anniversaryMonthEnabled = anniversaryMonthEnabled,
-                            onAnniversaryMonthChange = { anniversaryMonthEnabled = it },
-                            anniversaryWeekEnabled = anniversaryWeekEnabled,
-                            onAnniversaryWeekChange = { anniversaryWeekEnabled = it },
-                            anniversaryCombinedText = anniversaryCombinedText,
-                            onAnniversaryCombinedTextChange = { anniversaryCombinedText = it },
-                        )
-
-                        Button(
-                            onClick = { showDatePicker.value = false },
-                            enabled = isRepeatValid,
-                            modifier = Modifier.fillMaxWidth().height(48.dp),
-                            shape = RoundedCornerShape(14.dp)
-                        ) {
-                            Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
-                        }
-                    }
-                }
-            }
-        }
+        DateConfigurationWizard(
+            initialConfiguration = EventDateConfiguration(
+                targetDate = selectedDate,
+                mode = mode,
+                repeatMode = repeatMode,
+                repeatCustomDays = repeatCustomDays,
+                repeatAnchorDate = if (repeatMode == RepeatMode.NONE) null else selectedDate,
+                customAnniversaryDays = customAnniversaryDays,
+                anniversaryYearEnabled = anniversaryYearEnabled,
+                anniversaryMonthEnabled = anniversaryMonthEnabled,
+                anniversaryWeekEnabled = anniversaryWeekEnabled,
+                anniversaryCombinedText = anniversaryCombinedText,
+            ),
+            onConfirm = { configuration ->
+                selectedDate = configuration.targetDate
+                mode = configuration.mode
+                repeatMode = configuration.repeatMode
+                repeatCustomDays = configuration.repeatCustomDays
+                customAnniversaryDays = configuration.customAnniversaryDays
+                anniversaryYearEnabled = configuration.anniversaryYearEnabled
+                anniversaryMonthEnabled = configuration.anniversaryMonthEnabled
+                anniversaryWeekEnabled = configuration.anniversaryWeekEnabled
+                anniversaryCombinedText = configuration.anniversaryCombinedText
+                showDatePicker.value = false
+            },
+            onDismiss = { showDatePicker.value = false },
+        )
     }
 
     Scaffold(

--- a/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
@@ -53,6 +53,7 @@ import com.kippu.trace.ui.theme.KIPPU_TraceTheme
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.TextUtils
 import com.kippu.trace.utils.buildTitleWithPrefixAnnotatedString
+import com.kippu.trace.utils.isRepeatConfigurationValid
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -119,6 +120,7 @@ fun EditorScreen(
 
     val untitledText = stringResource(R.string.untitled)
     val sampleTitleText = stringResource(R.string.sample_title)
+    val isRepeatValid = isRepeatConfigurationValid(mode, repeatMode, repeatCustomDays)
 
     if (showDatePicker.value) {
         val datePickerState = rememberDatePickerState(initialSelectedDateMillis = selectedDate)
@@ -225,6 +227,7 @@ fun EditorScreen(
 
                         Button(
                             onClick = { showDatePicker.value = false },
+                            enabled = isRepeatValid,
                             modifier = Modifier.fillMaxWidth().height(48.dp),
                             shape = RoundedCornerShape(14.dp)
                         ) {
@@ -246,24 +249,27 @@ fun EditorScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = {
-                        onSave(DateEvent(
-                            title = titleState.text.toString().ifEmpty { untitledText },
-                            targetDate = selectedDate,
-                            isFuture = mode == DisplayMode.COUNT_DOWN,
-                            mode = mode,
-                            isPinned = isPinned,
-                            backgroundUri = backgroundUri,
-                            maskOpacity = maskOpacity,
-                            repeatMode = repeatMode,
-                            repeatCustomDays = repeatCustomDays,
-                            customAnniversaryDays = customAnniversaryDays,
-                            anniversaryYearEnabled = anniversaryYearEnabled,
-                            anniversaryMonthEnabled = anniversaryMonthEnabled,
-                            anniversaryWeekEnabled = anniversaryWeekEnabled,
-                            anniversaryCombinedText = anniversaryCombinedText,
-                        ))
-                    }) {
+                    IconButton(
+                        enabled = isRepeatValid,
+                        onClick = {
+                            onSave(DateEvent(
+                                title = titleState.text.toString().ifEmpty { untitledText },
+                                targetDate = selectedDate,
+                                isFuture = mode == DisplayMode.COUNT_DOWN,
+                                mode = mode,
+                                isPinned = isPinned,
+                                backgroundUri = backgroundUri,
+                                maskOpacity = maskOpacity,
+                                repeatMode = repeatMode,
+                                repeatCustomDays = repeatCustomDays,
+                                customAnniversaryDays = customAnniversaryDays,
+                                anniversaryYearEnabled = anniversaryYearEnabled,
+                                anniversaryMonthEnabled = anniversaryMonthEnabled,
+                                anniversaryWeekEnabled = anniversaryWeekEnabled,
+                                anniversaryCombinedText = anniversaryCombinedText,
+                            ))
+                        }
+                    ) {
                         Icon(painter = rememberVectorPainter(Icons.Default.Check), contentDescription = "Save", tint = MaterialTheme.colorScheme.primary)
                     }
                 }

--- a/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/EditorScreen.kt
@@ -262,6 +262,9 @@ fun EditorScreen(
                                 maskOpacity = maskOpacity,
                                 repeatMode = repeatMode,
                                 repeatCustomDays = repeatCustomDays,
+                                repeatAnchorDate = if (
+                                    mode == DisplayMode.COUNT_DOWN && repeatMode != RepeatMode.NONE
+                                ) selectedDate else null,
                                 customAnniversaryDays = customAnniversaryDays,
                                 anniversaryYearEnabled = anniversaryYearEnabled,
                                 anniversaryMonthEnabled = anniversaryMonthEnabled,

--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -53,6 +53,7 @@ import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.utils.FileUtils
 import kotlinx.coroutines.launch
+import com.kippu.trace.ui.components.AnniversaryConfigSection
 import com.kippu.trace.ui.components.NormalEventCard
 import com.kippu.trace.ui.components.PinnedEventCard
 import java.time.Instant
@@ -322,6 +323,24 @@ fun HomeScreen(
                 }
 
                 ModeSwitcher(selectedMode = event.mode, onModeSelected = { editingEvent = editingEvent?.copy(mode = it) })
+
+                AnniversaryConfigSection(
+                    mode = event.mode,
+                    repeatMode = event.repeatMode,
+                    onRepeatModeChange = { editingEvent = editingEvent?.copy(repeatMode = it) },
+                    repeatCustomDays = event.repeatCustomDays,
+                    onRepeatCustomDaysChange = { editingEvent = editingEvent?.copy(repeatCustomDays = it) },
+                    customAnniversaryDays = event.customAnniversaryDays,
+                    onCustomAnniversaryDaysChange = { editingEvent = editingEvent?.copy(customAnniversaryDays = it) },
+                    anniversaryYearEnabled = event.anniversaryYearEnabled,
+                    onAnniversaryYearChange = { editingEvent = editingEvent?.copy(anniversaryYearEnabled = it) },
+                    anniversaryMonthEnabled = event.anniversaryMonthEnabled,
+                    onAnniversaryMonthChange = { editingEvent = editingEvent?.copy(anniversaryMonthEnabled = it) },
+                    anniversaryWeekEnabled = event.anniversaryWeekEnabled,
+                    onAnniversaryWeekChange = { editingEvent = editingEvent?.copy(anniversaryWeekEnabled = it) },
+                    anniversaryCombinedText = event.anniversaryCombinedText,
+                    onAnniversaryCombinedTextChange = { editingEvent = editingEvent?.copy(anniversaryCombinedText = it) },
+                )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -222,17 +222,116 @@ fun HomeScreen(
         val showEditDatePicker = remember { mutableStateOf(false) }
 
         if (showEditDatePicker.value) {
-            EditDatePickerDialog(
-                initialDateMillis = event.targetDate,
-                onConfirm = { millis ->
-                    editingEvent = editingEvent?.copy(
-                        targetDate = millis,
-                        mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
-                    )
-                    showEditDatePicker.value = false
-                },
-                onDismiss = { showEditDatePicker.value = false }
-            )
+            val editDatePickerState = rememberDatePickerState(initialSelectedDateMillis = event.targetDate)
+            var editDatePickerStep by remember { mutableIntStateOf(0) }  // 0=日期选择 1=纪念日/重置设置
+
+            Dialog(
+                onDismissRequest = { showEditDatePicker.value = false },
+                properties = DialogProperties(usePlatformDefaultWidth = false)
+            ) {
+                Surface(
+                    shape = RoundedCornerShape(28.dp),
+                    color = MaterialTheme.colorScheme.surface,
+                    tonalElevation = 0.dp,
+                    modifier = Modifier
+                        .widthIn(min = 320.dp, max = 480.dp)
+                        .fillMaxWidth(0.85f)
+                        .wrapContentHeight()
+                ) {
+                    if (editDatePickerStep == 0) {
+                        // 第一步：选择日期
+                        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+                            val scale = (this.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
+                            Column(
+                                modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.select_date),
+                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                                    modifier = Modifier
+                                        .align(Alignment.Start)
+                                        .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
+                                )
+                                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                    DatePicker(
+                                        state = editDatePickerState,
+                                        title = null,
+                                        headline = null,
+                                        showModeToggle = false,
+                                        colors = DatePickerDefaults.colors(
+                                            containerColor = MaterialTheme.colorScheme.surface,
+                                            dividerColor = Color.Transparent
+                                        ),
+                                        modifier = Modifier
+                                            .requiredWidth(360.dp)
+                                            .scale(scale)
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                                    horizontalArrangement = Arrangement.End
+                                ) {
+                                    TextButton(onClick = { showEditDatePicker.value = false }) {
+                                        Text(stringResource(R.string.cancel))
+                                    }
+                                    TextButton(onClick = {
+                                        editDatePickerState.selectedDateMillis?.let { millis ->
+                                            editingEvent = editingEvent?.copy(
+                                                targetDate = millis,
+                                                mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
+                                            )
+                                        }
+                                        editDatePickerStep = 1
+                                    }) {
+                                        Text(stringResource(R.string.next))
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // 第二步：Reset / Anniversary 设置
+                        Column(
+                            modifier = Modifier.padding(24.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    if (event.mode == DisplayMode.COUNT_DOWN) R.string.repeat_section else R.string.anniversary_section
+                                ),
+                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+                            )
+
+                            AnniversaryConfigSection(
+                                mode = event.mode,
+                                repeatMode = event.repeatMode,
+                                onRepeatModeChange = { editingEvent = editingEvent?.copy(repeatMode = it) },
+                                repeatCustomDays = event.repeatCustomDays,
+                                onRepeatCustomDaysChange = { editingEvent = editingEvent?.copy(repeatCustomDays = it) },
+                                customAnniversaryDays = event.customAnniversaryDays,
+                                onCustomAnniversaryDaysChange = { editingEvent = editingEvent?.copy(customAnniversaryDays = it) },
+                                anniversaryYearEnabled = event.anniversaryYearEnabled,
+                                onAnniversaryYearChange = { editingEvent = editingEvent?.copy(anniversaryYearEnabled = it) },
+                                anniversaryMonthEnabled = event.anniversaryMonthEnabled,
+                                onAnniversaryMonthChange = { editingEvent = editingEvent?.copy(anniversaryMonthEnabled = it) },
+                                anniversaryWeekEnabled = event.anniversaryWeekEnabled,
+                                onAnniversaryWeekChange = { editingEvent = editingEvent?.copy(anniversaryWeekEnabled = it) },
+                                anniversaryCombinedText = event.anniversaryCombinedText,
+                                onAnniversaryCombinedTextChange = { editingEvent = editingEvent?.copy(anniversaryCombinedText = it) },
+                            )
+
+                            Button(
+                                onClick = { showEditDatePicker.value = false },
+                                modifier = Modifier.fillMaxWidth().height(48.dp),
+                                shape = RoundedCornerShape(14.dp)
+                            ) {
+                                Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         ModalBottomSheet(
@@ -323,24 +422,6 @@ fun HomeScreen(
                 }
 
                 ModeSwitcher(selectedMode = event.mode, onModeSelected = { editingEvent = editingEvent?.copy(mode = it) })
-
-                AnniversaryConfigSection(
-                    mode = event.mode,
-                    repeatMode = event.repeatMode,
-                    onRepeatModeChange = { editingEvent = editingEvent?.copy(repeatMode = it) },
-                    repeatCustomDays = event.repeatCustomDays,
-                    onRepeatCustomDaysChange = { editingEvent = editingEvent?.copy(repeatCustomDays = it) },
-                    customAnniversaryDays = event.customAnniversaryDays,
-                    onCustomAnniversaryDaysChange = { editingEvent = editingEvent?.copy(customAnniversaryDays = it) },
-                    anniversaryYearEnabled = event.anniversaryYearEnabled,
-                    onAnniversaryYearChange = { editingEvent = editingEvent?.copy(anniversaryYearEnabled = it) },
-                    anniversaryMonthEnabled = event.anniversaryMonthEnabled,
-                    onAnniversaryMonthChange = { editingEvent = editingEvent?.copy(anniversaryMonthEnabled = it) },
-                    anniversaryWeekEnabled = event.anniversaryWeekEnabled,
-                    onAnniversaryWeekChange = { editingEvent = editingEvent?.copy(anniversaryWeekEnabled = it) },
-                    anniversaryCombinedText = event.anniversaryCombinedText,
-                    onAnniversaryCombinedTextChange = { editingEvent = editingEvent?.copy(anniversaryCombinedText = it) },
-                )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -492,75 +573,6 @@ fun SwipeActionWrapper(
             }
         }
         Box(modifier = Modifier.fillMaxWidth().offset { IntOffset(offsetX.value.roundToInt(), 0) }) { content() }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun EditDatePickerDialog(
-    initialDateMillis: Long,
-    onConfirm: (Long) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val datePickerState = rememberDatePickerState(initialSelectedDateMillis = initialDateMillis)
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(usePlatformDefaultWidth = false)
-    ) {
-        Surface(
-            shape = RoundedCornerShape(28.dp),
-            color = MaterialTheme.colorScheme.surface,
-            tonalElevation = 0.dp,
-            modifier = Modifier
-                .widthIn(min = 320.dp, max = 480.dp)
-                .fillMaxWidth(0.85f)
-                .wrapContentHeight()
-        ) {
-            BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                val scale = (this.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
-                Column(
-                    modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = stringResource(R.string.select_date),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        modifier = Modifier
-                            .align(Alignment.Start)
-                            .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
-                    )
-                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                        DatePicker(
-                            state = datePickerState,
-                            title = null,
-                            headline = null,
-                            showModeToggle = false,
-                            colors = DatePickerDefaults.colors(
-                                containerColor = MaterialTheme.colorScheme.surface,
-                                dividerColor = Color.Transparent
-                            ),
-                            modifier = Modifier
-                                .requiredWidth(360.dp)
-                                .scale(scale)
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        TextButton(onClick = onDismiss) {
-                            Text(stringResource(R.string.cancel))
-                        }
-                        TextButton(onClick = {
-                            datePickerState.selectedDateMillis?.let { onConfirm(it) }
-                        }) {
-                            Text(stringResource(R.string.confirm))
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -46,20 +46,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
-import com.kippu.trace.model.RepeatMode
 import com.kippu.trace.utils.FileUtils
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.isRepeatConfigurationValid
 import kotlinx.coroutines.launch
-import com.kippu.trace.ui.components.AnniversaryConfigSection
+import com.kippu.trace.ui.components.DateConfigurationWizard
 import com.kippu.trace.ui.components.NormalEventCard
 import com.kippu.trace.ui.components.PinnedEventCard
-import java.time.Instant
-import java.time.ZoneId
+import com.kippu.trace.ui.components.toDateConfiguration
+import com.kippu.trace.ui.components.withDateConfiguration
 import java.time.format.DateTimeFormatter
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -229,130 +227,14 @@ fun HomeScreen(
         val showEditDatePicker = remember { mutableStateOf(false) }
 
         if (showEditDatePicker.value) {
-            val editDatePickerState = rememberDatePickerState(initialSelectedDateMillis = event.targetDate)
-            var editDatePickerStep by remember { mutableIntStateOf(0) }  // 0=日期选择 1=纪念日/重置设置
-
-            Dialog(
-                onDismissRequest = { showEditDatePicker.value = false },
-                properties = DialogProperties(usePlatformDefaultWidth = false)
-            ) {
-                Surface(
-                    shape = RoundedCornerShape(28.dp),
-                    color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 0.dp,
-                    modifier = Modifier
-                        .widthIn(min = 320.dp, max = 480.dp)
-                        .fillMaxWidth(0.85f)
-                        .wrapContentHeight()
-                ) {
-                    if (editDatePickerStep == 0) {
-                        // 第一步：选择日期
-                        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-                            val scale = (this.maxWidth / 360.dp).coerceIn(0.88f, 1.1f)
-                            Column(
-                                modifier = Modifier.padding(top = 20.dp, bottom = 16.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = stringResource(R.string.select_date),
-                                    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                                    modifier = Modifier
-                                        .align(Alignment.Start)
-                                        .padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
-                                )
-                                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                    DatePicker(
-                                        state = editDatePickerState,
-                                        title = null,
-                                        headline = null,
-                                        showModeToggle = false,
-                                        colors = DatePickerDefaults.colors(
-                                            containerColor = MaterialTheme.colorScheme.surface,
-                                            dividerColor = Color.Transparent
-                                        ),
-                                        modifier = Modifier
-                                            .requiredWidth(360.dp)
-                                            .scale(scale)
-                                    )
-                                }
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Row(
-                                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                                    horizontalArrangement = Arrangement.End
-                                ) {
-                                    TextButton(onClick = { showEditDatePicker.value = false }) {
-                                        Text(stringResource(R.string.cancel))
-                                    }
-                                    TextButton(onClick = {
-                                        editDatePickerState.selectedDateMillis?.let { millis ->
-                                            editingEvent = editingEvent?.copy(
-                                                targetDate = millis,
-                                                isFuture = millis > System.currentTimeMillis(),
-                                                mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE,
-                                                repeatAnchorDate = if (event.repeatMode != RepeatMode.NONE) millis else null,
-                                            )
-                                        }
-                                        editDatePickerStep = 1
-                                    }) {
-                                        Text(stringResource(R.string.next))
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        // 第二步：Reset / Anniversary 设置
-                        Column(
-                            modifier = Modifier.padding(24.dp),
-                            verticalArrangement = Arrangement.spacedBy(16.dp)
-                        ) {
-                            Text(
-                                text = stringResource(
-                                    if (event.mode == DisplayMode.COUNT_DOWN) R.string.repeat_section else R.string.anniversary_section
-                                ),
-                                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                            )
-
-                            AnniversaryConfigSection(
-                                mode = event.mode,
-                                repeatMode = event.repeatMode,
-                                onRepeatModeChange = { repeatMode ->
-                                    editingEvent = editingEvent?.let { current ->
-                                        current.copy(
-                                            repeatMode = repeatMode,
-                                            repeatAnchorDate = if (repeatMode == RepeatMode.NONE) {
-                                                null
-                                            } else {
-                                                current.repeatAnchorDate ?: current.targetDate
-                                            },
-                                        )
-                                    }
-                                },
-                                repeatCustomDays = event.repeatCustomDays,
-                                onRepeatCustomDaysChange = { editingEvent = editingEvent?.copy(repeatCustomDays = it) },
-                                customAnniversaryDays = event.customAnniversaryDays,
-                                onCustomAnniversaryDaysChange = { editingEvent = editingEvent?.copy(customAnniversaryDays = it) },
-                                anniversaryYearEnabled = event.anniversaryYearEnabled,
-                                onAnniversaryYearChange = { editingEvent = editingEvent?.copy(anniversaryYearEnabled = it) },
-                                anniversaryMonthEnabled = event.anniversaryMonthEnabled,
-                                onAnniversaryMonthChange = { editingEvent = editingEvent?.copy(anniversaryMonthEnabled = it) },
-                                anniversaryWeekEnabled = event.anniversaryWeekEnabled,
-                                onAnniversaryWeekChange = { editingEvent = editingEvent?.copy(anniversaryWeekEnabled = it) },
-                                anniversaryCombinedText = event.anniversaryCombinedText,
-                                onAnniversaryCombinedTextChange = { editingEvent = editingEvent?.copy(anniversaryCombinedText = it) },
-                            )
-
-                            Button(
-                                onClick = { showEditDatePicker.value = false },
-                                enabled = isRepeatValid,
-                                modifier = Modifier.fillMaxWidth().height(48.dp),
-                                shape = RoundedCornerShape(14.dp)
-                            ) {
-                                Text(stringResource(R.string.confirm), style = MaterialTheme.typography.labelLarge)
-                            }
-                        }
-                    }
-                }
-            }
+            DateConfigurationWizard(
+                initialConfiguration = event.toDateConfiguration(),
+                onConfirm = { configuration ->
+                    editingEvent = editingEvent?.withDateConfiguration(configuration)
+                    showEditDatePicker.value = false
+                },
+                onDismiss = { showEditDatePicker.value = false },
+            )
         }
 
         ModalBottomSheet(
@@ -402,7 +284,7 @@ fun HomeScreen(
 
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     val editTargetLocalDate = remember(event.targetDate) {
-                        Instant.ofEpochMilli(event.targetDate).atZone(ZoneId.systemDefault()).toLocalDate()
+                        EventDateUtils.fromStoredMillis(event.targetDate)
                     }
                     val editFormattedDate = remember(editTargetLocalDate) {
                         editTargetLocalDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
@@ -478,7 +360,7 @@ fun HomeScreen(
                         onUpdateEvent(
                             event.copy(
                                 title = titleState.text.toString().ifEmpty { context.getString(R.string.untitled) },
-                                isFuture = event.targetDate > System.currentTimeMillis()
+                                isFuture = event.mode == DisplayMode.COUNT_DOWN,
                             )
                         )
                         editingEvent = null

--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -52,6 +52,7 @@ import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.utils.FileUtils
+import com.kippu.trace.utils.isRepeatConfigurationValid
 import kotlinx.coroutines.launch
 import com.kippu.trace.ui.components.AnniversaryConfigSection
 import com.kippu.trace.ui.components.NormalEventCard
@@ -204,6 +205,11 @@ fun HomeScreen(
 
     if (editingEvent != null) {
         val event = editingEvent!!
+        val isRepeatValid = isRepeatConfigurationValid(
+            event.mode,
+            event.repeatMode,
+            event.repeatCustomDays,
+        )
         val titleState = rememberTextFieldState()
         LaunchedEffect(event.title) {
             if (titleState.text.toString() != event.title) {
@@ -280,6 +286,7 @@ fun HomeScreen(
                                         editDatePickerState.selectedDateMillis?.let { millis ->
                                             editingEvent = editingEvent?.copy(
                                                 targetDate = millis,
+                                                isFuture = millis > System.currentTimeMillis(),
                                                 mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
                                             )
                                         }
@@ -323,6 +330,7 @@ fun HomeScreen(
 
                             Button(
                                 onClick = { showEditDatePicker.value = false },
+                                enabled = isRepeatValid,
                                 modifier = Modifier.fillMaxWidth().height(48.dp),
                                 shape = RoundedCornerShape(14.dp)
                             ) {
@@ -462,6 +470,7 @@ fun HomeScreen(
                         )
                         editingEvent = null
                     },
+                    enabled = isRepeatValid,
                     modifier = Modifier.fillMaxWidth().height(48.dp),
                     shape = RoundedCornerShape(14.dp)
                 ) {

--- a/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/kippu/trace/ui/screens/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
 import com.kippu.trace.utils.FileUtils
 import com.kippu.trace.utils.isRepeatConfigurationValid
 import kotlinx.coroutines.launch
@@ -287,7 +288,8 @@ fun HomeScreen(
                                             editingEvent = editingEvent?.copy(
                                                 targetDate = millis,
                                                 isFuture = millis > System.currentTimeMillis(),
-                                                mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE
+                                                mode = if (millis > System.currentTimeMillis()) DisplayMode.COUNT_DOWN else DisplayMode.ACCUMULATE,
+                                                repeatAnchorDate = if (event.repeatMode != RepeatMode.NONE) millis else null,
                                             )
                                         }
                                         editDatePickerStep = 1
@@ -313,7 +315,18 @@ fun HomeScreen(
                             AnniversaryConfigSection(
                                 mode = event.mode,
                                 repeatMode = event.repeatMode,
-                                onRepeatModeChange = { editingEvent = editingEvent?.copy(repeatMode = it) },
+                                onRepeatModeChange = { repeatMode ->
+                                    editingEvent = editingEvent?.let { current ->
+                                        current.copy(
+                                            repeatMode = repeatMode,
+                                            repeatAnchorDate = if (repeatMode == RepeatMode.NONE) {
+                                                null
+                                            } else {
+                                                current.repeatAnchorDate ?: current.targetDate
+                                            },
+                                        )
+                                    }
+                                },
                                 repeatCustomDays = event.repeatCustomDays,
                                 onRepeatCustomDaysChange = { editingEvent = editingEvent?.copy(repeatCustomDays = it) },
                                 customAnniversaryDays = event.customAnniversaryDays,

--- a/app/src/main/java/com/kippu/trace/ui/theme/Color.kt
+++ b/app/src/main/java/com/kippu/trace/ui/theme/Color.kt
@@ -31,3 +31,7 @@ val GlassWhite = Color(0xCCFFFFFF)
 val GlassBlack = Color(0x66000000)
 
 val AccentColor = Color(0xFF007AFF)
+
+// 纪念日
+val AnniversaryGold = Color(0xFFB8860B)          // 浅色表面用
+val AnniversaryGoldOnDark = Color(0xFFFFD54F)    // 深色/黑色表面用

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -1,0 +1,230 @@
+package com.kippu.trace.utils
+
+import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.RepeatMode
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * 纪念日触发类型
+ */
+enum class AnniversaryType {
+    CUSTOM,  // 自定义 N 天
+    YEAR,    // 满年
+    MONTH,   // 满月
+    WEEK     // 满周
+}
+
+/**
+ * 纪念日计算结果
+ */
+data class AnniversaryResult(
+    val type: AnniversaryType,
+    val count: Int,       // 第 X 个周期 / 满 Y 年
+    val baseDays: Int = 0 // 自定义纪念日的 N 值
+)
+
+/**
+ * 累计模式下所有纪念日触发结果
+ */
+data class AnniversaryTrigger(
+    val results: List<AnniversaryResult>,
+    val combinedText: String?  // 用户自定义的合并文案，null 表示使用默认
+) {
+    val isTriggered: Boolean get() = results.isNotEmpty()
+
+    /** 默认拼接文案 */
+    fun defaultText(): String {
+        if (results.isEmpty()) return ""
+        return results.joinToString(" · ") { r ->
+            when (r.type) {
+                AnniversaryType.CUSTOM -> "${r.count}×${r.baseDays}天"
+                AnniversaryType.YEAR -> "满${r.count}年"
+                AnniversaryType.MONTH -> "满${r.count}月"
+                AnniversaryType.WEEK -> "满${r.count}周"
+            }
+        }
+    }
+
+    /** 最终展示文案：用户自定义优先，否则用默认 */
+    fun displayText(): String {
+        val custom = combinedText
+        if (!custom.isNullOrBlank()) return custom
+        return defaultText()
+    }
+}
+
+object AnniversaryUtils {
+
+    // ─────────── 累计模式 ───────────
+
+    /** 计算累计天数（目标日期到今天） */
+    fun accumulatedDays(targetDateMillis: Long): Long {
+        val targetDate = Instant.ofEpochMilli(targetDateMillis)
+            .atZone(ZoneId.of("UTC"))
+            .toLocalDate()
+        val today = LocalDate.now(ZoneId.systemDefault())
+        return ChronoUnit.DAYS.between(targetDate, today)
+    }
+
+    /** 检查自定义纪念日触发 */
+    fun checkCustomAnniversary(targetDateMillis: Long, n: Int): AnniversaryResult? {
+        if (n <= 0) return null
+        val days = accumulatedDays(targetDateMillis)
+        if (days > 0 && days % n == 0L) {
+            return AnniversaryResult(
+                type = AnniversaryType.CUSTOM,
+                count = (days / n).toInt(),
+                baseDays = n
+            )
+        }
+        return null
+    }
+
+    /** 检查系统预设纪念日（年/月/周） */
+    fun checkSystemAnniversary(
+        targetDateMillis: Long,
+        yearEnabled: Boolean,
+        monthEnabled: Boolean,
+        weekEnabled: Boolean
+    ): List<AnniversaryResult> {
+        val results = mutableListOf<AnniversaryResult>()
+
+        val targetDate = Instant.ofEpochMilli(targetDateMillis)
+            .atZone(ZoneId.of("UTC"))
+            .toLocalDate()
+        val today = LocalDate.now(ZoneId.systemDefault())
+
+        // 必须是自目标日期之后的未来/过去（非当天 && 非目标日期之前的一年内的同一天）
+        if (!today.isAfter(targetDate)) return emptyList()
+
+        val yearsDiff = today.year - targetDate.year
+
+        // 年纪念日：同月同日
+        if (yearEnabled &&
+            today.month == targetDate.month &&
+            today.dayOfMonth == targetDate.dayOfMonth &&
+            yearsDiff > 0
+        ) {
+            results.add(AnniversaryResult(type = AnniversaryType.YEAR, count = yearsDiff))
+        }
+
+        // 月纪念日：同日但不同月（且不是年纪念日的同一天）
+        val isYearDay = today.month == targetDate.month && today.dayOfMonth == targetDate.dayOfMonth
+        if (monthEnabled &&
+            today.dayOfMonth == targetDate.dayOfMonth &&
+            !isYearDay
+        ) {
+            // 计算自目标日期以来的累计月数
+            val monthsDiff = (yearsDiff * 12L +
+                    (today.monthValue - targetDate.monthValue).toLong())
+                .let { if (it < 0) it + 12 else it }
+            if (monthsDiff > 0) {
+                results.add(AnniversaryResult(type = AnniversaryType.MONTH, count = monthsDiff.toInt()))
+            }
+        }
+
+        // 周纪念日：同星期几
+        if (weekEnabled &&
+            today.dayOfWeek == targetDate.dayOfWeek &&
+            // 避免与年月日在同一天触发时过于密集，但不做排除
+            ChronoUnit.DAYS.between(targetDate, today) >= 7
+        ) {
+            val weeksDiff = ChronoUnit.WEEKS.between(targetDate, today)
+            if (weeksDiff > 0) {
+                results.add(AnniversaryResult(type = AnniversaryType.WEEK, count = weeksDiff.toInt()))
+            }
+        }
+
+        return results
+    }
+
+    /** 综合检查某 event 当天的纪念日触发情况 */
+    fun checkAllAnniversaries(event: DateEvent): AnniversaryTrigger {
+        if (event.mode != com.kippu.trace.model.DisplayMode.ACCUMULATE) {
+            return AnniversaryTrigger(emptyList(), null)
+        }
+
+        val results = mutableListOf<AnniversaryResult>()
+
+        // 自定义纪念日
+        if (event.customAnniversaryDays > 0) {
+            checkCustomAnniversary(event.targetDate, event.customAnniversaryDays)?.let {
+                results.add(it)
+            }
+        }
+
+        // 系统纪念日
+        results.addAll(
+            checkSystemAnniversary(
+                event.targetDate,
+                event.anniversaryYearEnabled,
+                event.anniversaryMonthEnabled,
+                event.anniversaryWeekEnabled
+            )
+        )
+
+        return AnniversaryTrigger(
+            results = results,
+            combinedText = if (results.size > 1) event.anniversaryCombinedText else null
+        )
+    }
+
+    // ─────────── 倒数模式 ───────────
+
+    /**
+     * 根据 RepeatMode 推进目标日期。
+     * 若目标日期未到则返回 null；若已过则按规则推进直到 > now，返回新时间戳。
+     */
+    fun advanceTargetDate(
+        currentTargetMillis: Long,
+        repeatMode: RepeatMode,
+        customDays: Int
+    ): Long? {
+        if (repeatMode == RepeatMode.NONE) return null
+
+        val systemZone = ZoneId.systemDefault()
+        val now = LocalDate.now(systemZone)
+
+        val targetDate = Instant.ofEpochMilli(currentTargetMillis)
+            .atZone(ZoneId.of("UTC"))
+            .toLocalDate()
+
+        // 目标日期还没到，无需推进
+        if (!targetDate.isBefore(now)) return null
+
+        var next = targetDate
+
+        when (repeatMode) {
+            RepeatMode.CUSTOM_DAYS -> {
+                if (customDays <= 0) return null
+                while (!next.isAfter(now)) {
+                    next = next.plusDays(customDays.toLong())
+                }
+            }
+            RepeatMode.WEEKLY -> {
+                while (!next.isAfter(now)) {
+                    next = next.plusWeeks(1)
+                }
+            }
+            RepeatMode.MONTHLY -> {
+                while (!next.isAfter(now)) {
+                    next = next.plusMonths(1)
+                }
+            }
+            RepeatMode.YEARLY -> {
+                while (!next.isAfter(now)) {
+                    next = next.plusYears(1)
+                }
+            }
+            RepeatMode.NONE -> return null
+        }
+
+        // 转换回 UTC 午夜毫秒时间戳（与 DatePicker.selectedDateMillis 保持一致）
+        return next.atStartOfDay(ZoneId.of("UTC"))
+            .toInstant()
+            .toEpochMilli()
+    }
+}

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -5,7 +5,6 @@ import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.model.RepeatMode
-import java.time.Instant
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.ZoneId
@@ -88,18 +87,22 @@ object AnniversaryUtils {
     // ─────────── 累计模式 ───────────
 
     /** 计算累计天数（目标日期到今天） */
-    fun accumulatedDays(targetDateMillis: Long): Long {
-        val targetDate = Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
-        val today = LocalDate.now(ZoneId.systemDefault())
+    fun accumulatedDays(
+        targetDateMillis: Long,
+        today: LocalDate = LocalDate.now(ZoneId.systemDefault()),
+    ): Long {
+        val targetDate = EventDateUtils.fromStoredMillis(targetDateMillis)
         return ChronoUnit.DAYS.between(targetDate, today)
     }
 
     /** 检查自定义纪念日触发 */
-    fun checkCustomAnniversary(targetDateMillis: Long, n: Int): AnniversaryResult? {
+    fun checkCustomAnniversary(
+        targetDateMillis: Long,
+        n: Int,
+        today: LocalDate = LocalDate.now(ZoneId.systemDefault()),
+    ): AnniversaryResult? {
         if (n <= 0) return null
-        val days = accumulatedDays(targetDateMillis)
+        val days = accumulatedDays(targetDateMillis, today)
         if (days > 0 && days % n == 0L) {
             return AnniversaryResult(
                 type = AnniversaryType.CUSTOM,
@@ -115,14 +118,12 @@ object AnniversaryUtils {
         targetDateMillis: Long,
         yearEnabled: Boolean,
         monthEnabled: Boolean,
-        weekEnabled: Boolean
+        weekEnabled: Boolean,
+        today: LocalDate = LocalDate.now(ZoneId.systemDefault()),
     ): List<AnniversaryResult> {
         val results = mutableListOf<AnniversaryResult>()
 
-        val targetDate = Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
-        val today = LocalDate.now(ZoneId.systemDefault())
+        val targetDate = EventDateUtils.fromStoredMillis(targetDateMillis)
 
         // 必须是自目标日期之后的未来/过去（非当天 && 非目标日期之前的一年内的同一天）
         if (!today.isAfter(targetDate)) return emptyList()
@@ -130,23 +131,21 @@ object AnniversaryUtils {
         val yearsDiff = today.year - targetDate.year
 
         // 年纪念日：同月同日
-        if (yearEnabled &&
-            today.month == targetDate.month &&
-            today.dayOfMonth == targetDate.dayOfMonth &&
-            yearsDiff > 0
+        if (
+            yearEnabled &&
+            yearsDiff > 0 &&
+            today == yearlyOccurrence(targetDate, yearsDiff)
         ) {
             results.add(AnniversaryResult(type = AnniversaryType.YEAR, count = yearsDiff))
         }
 
         // 月纪念日：每个完整月的同一天，周年当天也同时触发
-        if (monthEnabled &&
-            today.dayOfMonth == targetDate.dayOfMonth
-        ) {
-            // 计算自目标日期以来的累计月数
-            val monthsDiff = (yearsDiff * 12L +
-                    (today.monthValue - targetDate.monthValue).toLong())
-                .let { if (it < 0) it + 12 else it }
-            if (monthsDiff > 0) {
+        if (monthEnabled) {
+            val monthsDiff = ChronoUnit.MONTHS.between(
+                YearMonth.from(targetDate),
+                YearMonth.from(today),
+            )
+            if (monthsDiff > 0 && today == monthlyOccurrence(targetDate, monthsDiff)) {
                 results.add(AnniversaryResult(type = AnniversaryType.MONTH, count = monthsDiff.toInt()))
             }
         }
@@ -167,7 +166,10 @@ object AnniversaryUtils {
     }
 
     /** 综合检查某 event 当天的纪念日触发情况 */
-    fun checkAllAnniversaries(event: DateEvent): AnniversaryTrigger {
+    fun checkAllAnniversaries(
+        event: DateEvent,
+        today: LocalDate = LocalDate.now(ZoneId.systemDefault()),
+    ): AnniversaryTrigger {
         if (event.mode != com.kippu.trace.model.DisplayMode.ACCUMULATE) {
             return AnniversaryTrigger(emptyList(), null)
         }
@@ -176,7 +178,7 @@ object AnniversaryUtils {
 
         // 自定义纪念日
         if (event.customAnniversaryDays > 0) {
-            checkCustomAnniversary(event.targetDate, event.customAnniversaryDays)?.let {
+            checkCustomAnniversary(event.targetDate, event.customAnniversaryDays, today)?.let {
                 results.add(it)
             }
         }
@@ -187,7 +189,8 @@ object AnniversaryUtils {
                 event.targetDate,
                 event.anniversaryYearEnabled,
                 event.anniversaryMonthEnabled,
-                event.anniversaryWeekEnabled
+                event.anniversaryWeekEnabled,
+                today,
             )
         )
 
@@ -207,45 +210,39 @@ object AnniversaryUtils {
         currentTargetMillis: Long,
         repeatAnchorMillis: Long,
         repeatMode: RepeatMode,
-        customDays: Int
+        customDays: Int,
+        today: LocalDate = LocalDate.now(ZoneId.systemDefault()),
     ): Long? {
         if (repeatMode == RepeatMode.NONE) return null
 
-        val systemZone = ZoneId.systemDefault()
-        val now = LocalDate.now(systemZone)
-
-        val targetDate = Instant.ofEpochMilli(currentTargetMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
-        val anchorDate = Instant.ofEpochMilli(repeatAnchorMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
+        val targetDate = EventDateUtils.fromStoredMillis(currentTargetMillis)
+        val anchorDate = EventDateUtils.fromStoredMillis(repeatAnchorMillis)
 
         // 目标日期还没到，无需推进
-        if (!targetDate.isBefore(now)) return null
+        if (!targetDate.isBefore(today)) return null
 
         val next = when (repeatMode) {
             RepeatMode.CUSTOM_DAYS -> {
                 if (customDays <= 0) return null
-                nextDayBasedOccurrence(anchorDate, now, customDays.toLong())
+                nextDayBasedOccurrence(anchorDate, today, customDays.toLong())
             }
-            RepeatMode.WEEKLY -> nextDayBasedOccurrence(anchorDate, now, 7L)
+            RepeatMode.WEEKLY -> nextDayBasedOccurrence(anchorDate, today, 7L)
             RepeatMode.MONTHLY -> {
                 var offset = ChronoUnit.MONTHS.between(
                     YearMonth.from(anchorDate),
-                    YearMonth.from(now),
+                    YearMonth.from(today),
                 ).coerceAtLeast(0L)
                 var candidate = monthlyOccurrence(anchorDate, offset)
-                if (!candidate.isAfter(now)) {
+                if (!candidate.isAfter(today)) {
                     offset += 1
                     candidate = monthlyOccurrence(anchorDate, offset)
                 }
                 candidate
             }
             RepeatMode.YEARLY -> {
-                var offset = (now.year - anchorDate.year).coerceAtLeast(0)
+                var offset = (today.year - anchorDate.year).coerceAtLeast(0)
                 var candidate = yearlyOccurrence(anchorDate, offset)
-                if (!candidate.isAfter(now)) {
+                if (!candidate.isAfter(today)) {
                     offset += 1
                     candidate = yearlyOccurrence(anchorDate, offset)
                 }
@@ -255,9 +252,7 @@ object AnniversaryUtils {
         }
 
         // 转换回 UTC 午夜毫秒时间戳（与 DatePicker.selectedDateMillis 保持一致）
-        return next.atStartOfDay(ZoneId.of("UTC"))
-            .toInstant()
-            .toEpochMilli()
+        return EventDateUtils.toUtcMillis(next)
     }
 
     private fun nextDayBasedOccurrence(

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -1,5 +1,7 @@
 package com.kippu.trace.utils
 
+import android.content.res.Resources
+import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.RepeatMode
 import java.time.Instant
@@ -35,24 +37,27 @@ data class AnniversaryTrigger(
 ) {
     val isTriggered: Boolean get() = results.isNotEmpty()
 
-    /** 默认拼接文案 */
-    fun defaultText(): String {
+    private fun defaultText(resources: Resources): String {
         if (results.isEmpty()) return ""
         return results.joinToString(" · ") { r ->
             when (r.type) {
-                AnniversaryType.CUSTOM -> "${r.count}×${r.baseDays}天"
-                AnniversaryType.YEAR -> "满${r.count}年"
-                AnniversaryType.MONTH -> "满${r.count}月"
-                AnniversaryType.WEEK -> "满${r.count}周"
+                AnniversaryType.CUSTOM -> resources.getString(
+                    R.string.anniversary_custom_text,
+                    r.count,
+                    r.baseDays,
+                )
+                AnniversaryType.YEAR -> resources.getString(R.string.anniversary_year_text, r.count)
+                AnniversaryType.MONTH -> resources.getString(R.string.anniversary_month_text, r.count)
+                AnniversaryType.WEEK -> resources.getString(R.string.anniversary_week_text, r.count)
             }
         }
     }
 
     /** 最终展示文案：用户自定义优先，否则用默认 */
-    fun displayText(): String {
+    fun displayText(resources: Resources): String {
         val custom = combinedText
         if (!custom.isNullOrBlank()) return custom
-        return defaultText()
+        return defaultText(resources)
     }
 }
 

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -7,6 +7,7 @@ import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.model.RepeatMode
 import java.time.Instant
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
@@ -204,6 +205,7 @@ object AnniversaryUtils {
      */
     fun advanceTargetDate(
         currentTargetMillis: Long,
+        repeatAnchorMillis: Long,
         repeatMode: RepeatMode,
         customDays: Int
     ): Long? {
@@ -215,33 +217,39 @@ object AnniversaryUtils {
         val targetDate = Instant.ofEpochMilli(currentTargetMillis)
             .atZone(ZoneId.of("UTC"))
             .toLocalDate()
+        val anchorDate = Instant.ofEpochMilli(repeatAnchorMillis)
+            .atZone(ZoneId.of("UTC"))
+            .toLocalDate()
 
         // 目标日期还没到，无需推进
         if (!targetDate.isBefore(now)) return null
 
-        var next = targetDate
-
-        when (repeatMode) {
+        val next = when (repeatMode) {
             RepeatMode.CUSTOM_DAYS -> {
                 if (customDays <= 0) return null
-                while (!next.isAfter(now)) {
-                    next = next.plusDays(customDays.toLong())
-                }
+                nextDayBasedOccurrence(anchorDate, now, customDays.toLong())
             }
-            RepeatMode.WEEKLY -> {
-                while (!next.isAfter(now)) {
-                    next = next.plusWeeks(1)
-                }
-            }
+            RepeatMode.WEEKLY -> nextDayBasedOccurrence(anchorDate, now, 7L)
             RepeatMode.MONTHLY -> {
-                while (!next.isAfter(now)) {
-                    next = next.plusMonths(1)
+                var offset = ChronoUnit.MONTHS.between(
+                    YearMonth.from(anchorDate),
+                    YearMonth.from(now),
+                ).coerceAtLeast(0L)
+                var candidate = monthlyOccurrence(anchorDate, offset)
+                if (!candidate.isAfter(now)) {
+                    offset += 1
+                    candidate = monthlyOccurrence(anchorDate, offset)
                 }
+                candidate
             }
             RepeatMode.YEARLY -> {
-                while (!next.isAfter(now)) {
-                    next = next.plusYears(1)
+                var offset = (now.year - anchorDate.year).coerceAtLeast(0)
+                var candidate = yearlyOccurrence(anchorDate, offset)
+                if (!candidate.isAfter(now)) {
+                    offset += 1
+                    candidate = yearlyOccurrence(anchorDate, offset)
                 }
+                candidate
             }
             RepeatMode.NONE -> return null
         }
@@ -250,5 +258,26 @@ object AnniversaryUtils {
         return next.atStartOfDay(ZoneId.of("UTC"))
             .toInstant()
             .toEpochMilli()
+    }
+
+    private fun nextDayBasedOccurrence(
+        anchorDate: LocalDate,
+        now: LocalDate,
+        intervalDays: Long,
+    ): LocalDate {
+        if (anchorDate.isAfter(now)) return anchorDate
+        val elapsedDays = ChronoUnit.DAYS.between(anchorDate, now)
+        val completedIntervals = elapsedDays / intervalDays
+        return anchorDate.plusDays((completedIntervals + 1) * intervalDays)
+    }
+
+    private fun monthlyOccurrence(anchorDate: LocalDate, offset: Long): LocalDate {
+        val targetMonth = YearMonth.from(anchorDate).plusMonths(offset)
+        return targetMonth.atDay(anchorDate.dayOfMonth.coerceAtMost(targetMonth.lengthOfMonth()))
+    }
+
+    private fun yearlyOccurrence(anchorDate: LocalDate, offset: Int): LocalDate {
+        val targetMonth = YearMonth.of(anchorDate.year + offset, anchorDate.month)
+        return targetMonth.atDay(anchorDate.dayOfMonth.coerceAtMost(targetMonth.lengthOfMonth()))
     }
 }

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -3,11 +3,20 @@ package com.kippu.trace.utils
 import android.content.res.Resources
 import com.kippu.trace.R
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.DisplayMode
 import com.kippu.trace.model.RepeatMode
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+
+fun isRepeatConfigurationValid(
+    mode: DisplayMode,
+    repeatMode: RepeatMode,
+    repeatCustomDays: Int,
+): Boolean = mode != DisplayMode.COUNT_DOWN ||
+        repeatMode != RepeatMode.CUSTOM_DAYS ||
+        repeatCustomDays > 0
 
 /**
  * 纪念日触发类型
@@ -46,9 +55,21 @@ data class AnniversaryTrigger(
                     r.count,
                     r.baseDays,
                 )
-                AnniversaryType.YEAR -> resources.getString(R.string.anniversary_year_text, r.count)
-                AnniversaryType.MONTH -> resources.getString(R.string.anniversary_month_text, r.count)
-                AnniversaryType.WEEK -> resources.getString(R.string.anniversary_week_text, r.count)
+                AnniversaryType.YEAR -> resources.getQuantityString(
+                    R.plurals.anniversary_year_text,
+                    r.count,
+                    r.count,
+                )
+                AnniversaryType.MONTH -> resources.getQuantityString(
+                    R.plurals.anniversary_month_text,
+                    r.count,
+                    r.count,
+                )
+                AnniversaryType.WEEK -> resources.getQuantityString(
+                    R.plurals.anniversary_week_text,
+                    r.count,
+                    r.count,
+                )
             }
         }
     }

--- a/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/AnniversaryUtils.kt
@@ -111,11 +111,9 @@ object AnniversaryUtils {
             results.add(AnniversaryResult(type = AnniversaryType.YEAR, count = yearsDiff))
         }
 
-        // 月纪念日：同日但不同月（且不是年纪念日的同一天）
-        val isYearDay = today.month == targetDate.month && today.dayOfMonth == targetDate.dayOfMonth
+        // 月纪念日：每个完整月的同一天，周年当天也同时触发
         if (monthEnabled &&
-            today.dayOfMonth == targetDate.dayOfMonth &&
-            !isYearDay
+            today.dayOfMonth == targetDate.dayOfMonth
         ) {
             // 计算自目标日期以来的累计月数
             val monthsDiff = (yearsDiff * 12L +

--- a/app/src/main/java/com/kippu/trace/utils/BackupManager.kt
+++ b/app/src/main/java/com/kippu/trace/utils/BackupManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -124,6 +125,21 @@ object BackupManager {
             }
             put("isPinned", isPinned)
             put("maskOpacity", maskOpacity.toDouble())
+            // 倒数模式 - 自动重置
+            put("repeatMode", repeatMode.name)
+            if (repeatCustomDays > 0) {
+                put("repeatCustomDays", repeatCustomDays)
+            }
+            // 累计模式 - 纪念日
+            if (customAnniversaryDays > 0) {
+                put("customAnniversaryDays", customAnniversaryDays)
+            }
+            put("anniversaryYearEnabled", anniversaryYearEnabled)
+            put("anniversaryMonthEnabled", anniversaryMonthEnabled)
+            put("anniversaryWeekEnabled", anniversaryWeekEnabled)
+            if (anniversaryCombinedText.isNotEmpty()) {
+                put("anniversaryCombinedText", anniversaryCombinedText)
+            }
         }
     }
 
@@ -140,6 +156,13 @@ object BackupManager {
             } else null,
             isPinned = optBoolean("isPinned", false),
             maskOpacity = optDouble("maskOpacity", 0.3).toFloat(),
+            repeatMode = if (has("repeatMode")) RepeatMode.valueOf(getString("repeatMode")) else RepeatMode.NONE,
+            repeatCustomDays = optInt("repeatCustomDays", 0),
+            customAnniversaryDays = optInt("customAnniversaryDays", 0),
+            anniversaryYearEnabled = optBoolean("anniversaryYearEnabled", false),
+            anniversaryMonthEnabled = optBoolean("anniversaryMonthEnabled", false),
+            anniversaryWeekEnabled = optBoolean("anniversaryWeekEnabled", false),
+            anniversaryCombinedText = optString("anniversaryCombinedText", ""),
         )
     }
 }

--- a/app/src/main/java/com/kippu/trace/utils/BackupManager.kt
+++ b/app/src/main/java/com/kippu/trace/utils/BackupManager.kt
@@ -130,6 +130,9 @@ object BackupManager {
             if (repeatCustomDays > 0) {
                 put("repeatCustomDays", repeatCustomDays)
             }
+            if (repeatMode != RepeatMode.NONE) {
+                put("repeatAnchorDate", repeatAnchorDate ?: targetDate)
+            }
             // 累计模式 - 纪念日
             if (customAnniversaryDays > 0) {
                 put("customAnniversaryDays", customAnniversaryDays)
@@ -144,10 +147,16 @@ object BackupManager {
     }
 
     private fun JSONObject.toDateEvent(backgroundsDir: File): DateEvent {
+        val targetDate = getLong("targetDate")
+        val repeatMode = if (has("repeatMode")) {
+            RepeatMode.valueOf(getString("repeatMode"))
+        } else {
+            RepeatMode.NONE
+        }
         return DateEvent(
             id = getLong("id"),
             title = getString("title"),
-            targetDate = getLong("targetDate"),
+            targetDate = targetDate,
             isFuture = getBoolean("isFuture"),
             isLunar = optBoolean("isLunar", false),
             mode = DisplayMode.valueOf(getString("mode")),
@@ -156,8 +165,13 @@ object BackupManager {
             } else null,
             isPinned = optBoolean("isPinned", false),
             maskOpacity = optDouble("maskOpacity", 0.3).toFloat(),
-            repeatMode = if (has("repeatMode")) RepeatMode.valueOf(getString("repeatMode")) else RepeatMode.NONE,
+            repeatMode = repeatMode,
             repeatCustomDays = optInt("repeatCustomDays", 0),
+            repeatAnchorDate = if (repeatMode != RepeatMode.NONE) {
+                optLong("repeatAnchorDate", targetDate)
+            } else {
+                null
+            },
             customAnniversaryDays = optInt("customAnniversaryDays", 0),
             anniversaryYearEnabled = optBoolean("anniversaryYearEnabled", false),
             anniversaryMonthEnabled = optBoolean("anniversaryMonthEnabled", false),

--- a/app/src/main/java/com/kippu/trace/utils/EventDateUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/EventDateUtils.kt
@@ -1,0 +1,36 @@
+package com.kippu.trace.utils
+
+import com.kippu.trace.model.DisplayMode
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+object EventDateUtils {
+    private const val MILLIS_PER_DAY = 86_400_000L
+
+    fun fromStoredMillis(
+        dateMillis: Long,
+        legacyZone: ZoneId = ZoneId.systemDefault(),
+    ): LocalDate = if (Math.floorMod(dateMillis, MILLIS_PER_DAY) == 0L) {
+        fromUtcMillis(dateMillis)
+    } else {
+        Instant.ofEpochMilli(dateMillis).atZone(legacyZone).toLocalDate()
+    }
+
+    private fun fromUtcMillis(dateMillis: Long): LocalDate =
+        Instant.ofEpochMilli(dateMillis).atZone(ZoneOffset.UTC).toLocalDate()
+
+    fun toUtcMillis(date: LocalDate): Long =
+        date.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+
+    fun displayModeFor(
+        dateMillis: Long,
+        today: LocalDate = LocalDate.now(),
+        legacyZone: ZoneId = ZoneId.systemDefault(),
+    ): DisplayMode = if (fromStoredMillis(dateMillis, legacyZone).isAfter(today)) {
+        DisplayMode.COUNT_DOWN
+    } else {
+        DisplayMode.ACCUMULATE
+    }
+}

--- a/app/src/main/java/com/kippu/trace/utils/TextUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/TextUtils.kt
@@ -1,7 +1,5 @@
 package com.kippu.trace.utils
 
-import kotlin.math.ceil
-
 object TextUtils {
     //计算视觉宽度 中文一倍 英文数字符号则为 0.5
     fun getVisualWidth(text: String): Float {

--- a/app/src/main/java/com/kippu/trace/utils/TimeUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/TimeUtils.kt
@@ -3,7 +3,6 @@ package com.kippu.trace.utils
 import android.content.Context
 import com.kippu.trace.R
 import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
 import java.time.Period
 import java.time.ZoneId
@@ -30,9 +29,7 @@ object TimeUtils {
         val systemZone = ZoneId.systemDefault()
         
         // 本地日期
-        val targetDate = Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
+        val targetDate = EventDateUtils.fromStoredMillis(targetDateMillis)
         val today = LocalDate.now(systemZone)
         
         val start = if (today.isBefore(targetDate)) today else targetDate
@@ -72,9 +69,7 @@ object TimeUtils {
         val now = ZonedDateTime.now(systemZone)
         
         // 将 DatePicker 的 UTC 午夜视为本地午夜
-        val targetMidnight = Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.of("UTC"))
-            .toLocalDate()
+        val targetMidnight = EventDateUtils.fromStoredMillis(targetDateMillis)
             .atStartOfDay(systemZone)
             
         val duration = if (now.isBefore(targetMidnight)) {

--- a/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
@@ -7,12 +7,41 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 // 根据实际可见行数计算最后一行占比，避免只淡出文字下半部分。
 fun getLastLineHeightFraction(lineCount: Int): Float {
     return 1f / lineCount.coerceAtLeast(1)
+}
+
+/**
+ * 构建详情页标题 AnnotatedString：每 [chunkSize] 字换行，末尾追加半透明前缀。
+ * 标题超过 [maxLength] 时截断并加省略号。
+ */
+fun buildTitleWithPrefixAnnotatedString(
+    title: String,
+    prefix: String,
+    maxLength: Int = 35,
+    chunkSize: Int = 9,
+    prefixColor: Color = Color.White.copy(alpha = 0.7f),
+) = buildAnnotatedString {
+    val displayTitle = if (title.length > maxLength) {
+        title.take(maxLength - 3) + "..."
+    } else {
+        title
+    }
+    val chunks = displayTitle.chunked(chunkSize)
+    chunks.forEachIndexed { index, chunk ->
+        append(chunk)
+        if (index < chunks.size - 1) append("\n")
+    }
+    append(" ")
+    pushStyle(SpanStyle(color = prefixColor))
+    append(prefix)
+    pop()
 }
 
 // 右侧边缘淡出效果

--- a/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
@@ -1,11 +1,5 @@
 package com.kippu.trace.utils
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.BlendMode
@@ -17,28 +11,6 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
-import java.time.Duration
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZonedDateTime
-
-@Composable
-fun rememberCurrentDate(zoneId: ZoneId = ZoneId.systemDefault()): LocalDate {
-    var currentDate by remember(zoneId) { mutableStateOf(LocalDate.now(zoneId)) }
-
-    LaunchedEffect(zoneId) {
-        while (true) {
-            val now = ZonedDateTime.now(zoneId)
-            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(zoneId)
-            delay(Duration.between(now, nextMidnight).toMillis().coerceAtLeast(1L))
-            currentDate = LocalDate.now(zoneId)
-        }
-    }
-
-    return currentDate
-}
-
 // 根据实际可见行数计算最后一行占比，避免只淡出文字下半部分。
 fun getLastLineHeightFraction(lineCount: Int): Float {
     return 1f / lineCount.coerceAtLeast(1)

--- a/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
+++ b/app/src/main/java/com/kippu/trace/utils/UIUtils.kt
@@ -1,5 +1,11 @@
 package com.kippu.trace.utils
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.BlendMode
@@ -11,6 +17,27 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+@Composable
+fun rememberCurrentDate(zoneId: ZoneId = ZoneId.systemDefault()): LocalDate {
+    var currentDate by remember(zoneId) { mutableStateOf(LocalDate.now(zoneId)) }
+
+    LaunchedEffect(zoneId) {
+        while (true) {
+            val now = ZonedDateTime.now(zoneId)
+            val nextMidnight = now.toLocalDate().plusDays(1).atStartOfDay(zoneId)
+            delay(Duration.between(now, nextMidnight).toMillis().coerceAtLeast(1L))
+            currentDate = LocalDate.now(zoneId)
+        }
+    }
+
+    return currentDate
+}
 
 // 根据实际可见行数计算最后一行占比，避免只淡出文字下半部分。
 fun getLastLineHeightFraction(lineCount: Int): Float {

--- a/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
@@ -8,6 +8,9 @@ import androidx.lifecycle.viewModelScope
 import com.kippu.trace.data.AppDatabase
 import com.kippu.trace.data.EventRepository
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import com.kippu.trace.utils.AnniversaryUtils
 import com.kippu.trace.utils.BackupManager
 import com.kippu.trace.widget.TraceWidgetUpdater
 import kotlinx.coroutines.Dispatchers
@@ -16,10 +19,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
 
 class EventViewModel(application: Application) : AndroidViewModel(application) {
     private val repository: EventRepository
     val allEvents: StateFlow<List<DateEvent>>
+
+    private val advancing = AtomicBoolean(false)
 
     init {
         val eventDao = AppDatabase.getDatabase(application).eventDao()
@@ -29,6 +35,33 @@ class EventViewModel(application: Application) : AndroidViewModel(application) {
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList(),
         )
+        checkAndAdvanceCountdowns()
+    }
+
+    /** 检查所有倒数模式事件，若目标日期已过则按重复规则推进 */
+    fun checkAndAdvanceCountdowns() {
+        if (!advancing.compareAndSet(false, true)) return
+        viewModelScope.launch {
+            try {
+                val events = withContext(Dispatchers.IO) { repository.getAllEventsOnce() }
+                val updated = events.mapNotNull { event ->
+                    if (event.mode == DisplayMode.COUNT_DOWN && event.repeatMode != RepeatMode.NONE) {
+                        val newTarget = AnniversaryUtils.advanceTargetDate(
+                            event.targetDate, event.repeatMode, event.repeatCustomDays
+                        )
+                        if (newTarget != null) {
+                            event.copy(targetDate = newTarget, isFuture = true)
+                        } else null
+                    } else null
+                }
+                if (updated.isNotEmpty()) {
+                    withContext(Dispatchers.IO) { repository.updateEvents(updated) }
+                    TraceWidgetUpdater.requestAllUpdate(getApplication())
+                }
+            } finally {
+                advancing.set(false)
+            }
+        }
     }
 
     fun addEvent(event: DateEvent) {

--- a/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
@@ -43,27 +43,34 @@ class EventViewModel(application: Application) : AndroidViewModel(application) {
         if (!advancing.compareAndSet(false, true)) return
         viewModelScope.launch {
             try {
-                val events = withContext(Dispatchers.IO) { repository.getAllEventsOnce() }
-                val updated = events.mapNotNull { event ->
-                    if (event.mode == DisplayMode.COUNT_DOWN && event.repeatMode != RepeatMode.NONE) {
+                val updatedCount = withContext(Dispatchers.IO) {
+                    var count = 0
+                    for (event in repository.getAllEventsOnce()) {
+                        if (event.mode != DisplayMode.COUNT_DOWN || event.repeatMode == RepeatMode.NONE) {
+                            continue
+                        }
+
                         val repeatAnchor = event.repeatAnchorDate ?: event.targetDate
                         val newTarget = AnniversaryUtils.advanceTargetDate(
                             event.targetDate,
                             repeatAnchor,
                             event.repeatMode,
                             event.repeatCustomDays,
-                        )
-                        if (newTarget != null) {
-                            event.copy(
-                                targetDate = newTarget,
-                                isFuture = true,
-                                repeatAnchorDate = repeatAnchor,
+                        ) ?: continue
+
+                        if (
+                            repository.advanceCountdownIfUnchanged(
+                                event = event,
+                                newTargetDate = newTarget,
+                                newAnchorDate = repeatAnchor,
                             )
-                        } else null
-                    } else null
+                        ) {
+                            count += 1
+                        }
+                    }
+                    count
                 }
-                if (updated.isNotEmpty()) {
-                    withContext(Dispatchers.IO) { repository.updateEvents(updated) }
+                if (updatedCount > 0) {
                     TraceWidgetUpdater.requestAllUpdate(getApplication())
                 }
             } finally {

--- a/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
+++ b/app/src/main/java/com/kippu/trace/viewmodel/EventViewModel.kt
@@ -46,11 +46,19 @@ class EventViewModel(application: Application) : AndroidViewModel(application) {
                 val events = withContext(Dispatchers.IO) { repository.getAllEventsOnce() }
                 val updated = events.mapNotNull { event ->
                     if (event.mode == DisplayMode.COUNT_DOWN && event.repeatMode != RepeatMode.NONE) {
+                        val repeatAnchor = event.repeatAnchorDate ?: event.targetDate
                         val newTarget = AnniversaryUtils.advanceTargetDate(
-                            event.targetDate, event.repeatMode, event.repeatCustomDays
+                            event.targetDate,
+                            repeatAnchor,
+                            event.repeatMode,
+                            event.repeatCustomDays,
                         )
                         if (newTarget != null) {
-                            event.copy(targetDate = newTarget, isFuture = true)
+                            event.copy(
+                                targetDate = newTarget,
+                                isFuture = true,
+                                repeatAnchorDate = repeatAnchor,
+                            )
                         } else null
                     } else null
                 }
@@ -66,7 +74,14 @@ class EventViewModel(application: Application) : AndroidViewModel(application) {
 
     fun addEvent(event: DateEvent) {
         viewModelScope.launch {
-            repository.insert(event)
+            val eventWithAnchor = if (
+                event.repeatMode != RepeatMode.NONE && event.repeatAnchorDate == null
+            ) {
+                event.copy(repeatAnchorDate = event.targetDate)
+            } else {
+                event
+            }
+            repository.insert(eventWithAnchor)
             TraceWidgetUpdater.requestAllUpdate(getApplication())
         }
     }

--- a/app/src/main/java/com/kippu/trace/widget/TraceWidgetUpdater.kt
+++ b/app/src/main/java/com/kippu/trace/widget/TraceWidgetUpdater.kt
@@ -13,12 +13,11 @@ import com.kippu.trace.MainActivity
 import com.kippu.trace.R
 import com.kippu.trace.data.AppDatabase
 import com.kippu.trace.model.DateEvent
+import com.kippu.trace.utils.EventDateUtils
 import com.kippu.trace.utils.LanguageMode
 import com.kippu.trace.utils.LanguagePreferences
 import com.kippu.trace.utils.TextUtils
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -257,18 +256,13 @@ object TraceWidgetUpdater {
     }
 
     private fun calculateDays(targetDateMillis: Long): Long {
-        val targetLocalDate = Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.systemDefault())
-            .toLocalDate()
+        val targetLocalDate = EventDateUtils.fromStoredMillis(targetDateMillis)
         val today = LocalDate.now()
         return ChronoUnit.DAYS.between(today, targetLocalDate).let { if (it < 0) -it else it }
     }
 
     private fun formatTargetDate(targetDateMillis: Long): String {
-        return Instant.ofEpochMilli(targetDateMillis)
-            .atZone(ZoneId.systemDefault())
-            .toLocalDate()
-            .format(dateFormatter)
+        return EventDateUtils.fromStoredMillis(targetDateMillis).format(dateFormatter)
     }
 
     private fun dpToPx(context: Context, dp: Int): Int {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -91,4 +91,24 @@
     <string name="restore_failed">Restore failed: %s</string>
     <string name="unknown_error">Unknown error</string>
     <string name="select_date">Select Date</string>
+    <!-- Anniversary / Repeat -->
+    <string name="anniversary_section">Anniversary</string>
+    <string name="anniversary_custom_label">Custom Anniversary</string>
+    <string name="anniversary_custom_unit">days</string>
+    <string name="anniversary_year">Year Anniversary</string>
+    <string name="anniversary_month">Month Anniversary</string>
+    <string name="anniversary_week">Week Anniversary</string>
+    <string name="anniversary_combined_hint">Custom text when multiple trigger (optional)</string>
+    <string name="repeat_section">Auto Reset</string>
+    <string name="repeat_none">Never</string>
+    <string name="repeat_yearly">Yearly</string>
+    <string name="repeat_monthly">Monthly</string>
+    <string name="repeat_weekly">Weekly</string>
+    <string name="repeat_custom">Custom</string>
+    <string name="repeat_custom_unit">days</string>
+    <string name="anniversary_custom_text">%1$d × %2$d days today</string>
+    <string name="anniversary_year_text">%d year(s) today</string>
+    <string name="anniversary_month_text">%d month(s) today</string>
+    <string name="anniversary_indicator">Anniversary</string>
+    <string name="anniversary_week_text">%d week(s) today</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -11,6 +11,7 @@
     <string name="close">Close</string>
     <string name="confirm">Confirm</string>
     <string name="cancel">Cancel</string>
+    <string name="next">Next</string>
     <string name="follow_system">System</string>
     <string name="light_mode">Light</string>
     <string name="dark_mode">Dark</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -108,8 +108,17 @@
     <string name="repeat_custom">Custom</string>
     <string name="repeat_custom_unit">days</string>
     <string name="anniversary_custom_text">%1$d × %2$d days today</string>
-    <string name="anniversary_year_text">%d year(s) today</string>
-    <string name="anniversary_month_text">%d month(s) today</string>
+    <plurals name="anniversary_year_text">
+        <item quantity="one">%d year today</item>
+        <item quantity="other">%d years today</item>
+    </plurals>
+    <plurals name="anniversary_month_text">
+        <item quantity="one">%d month today</item>
+        <item quantity="other">%d months today</item>
+    </plurals>
     <string name="anniversary_indicator">Anniversary</string>
-    <string name="anniversary_week_text">%d week(s) today</string>
+    <plurals name="anniversary_week_text">
+        <item quantity="one">%d week today</item>
+        <item quantity="other">%d weeks today</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -91,4 +91,24 @@
     <string name="restore_failed">復元に失敗しました: %s</string>
     <string name="unknown_error">不明なエラー</string>
     <string name="select_date">日付を選択</string>
+    <!-- 記念日 / リピート -->
+    <string name="anniversary_section">記念日設定</string>
+    <string name="anniversary_custom_label">カスタム記念日</string>
+    <string name="anniversary_custom_unit">日ごと</string>
+    <string name="anniversary_year">年記念日</string>
+    <string name="anniversary_month">月記念日</string>
+    <string name="anniversary_week">週記念日</string>
+    <string name="anniversary_combined_hint">同時発生時のカスタムテキスト（任意）</string>
+    <string name="repeat_section">自動リセット</string>
+    <string name="repeat_none">繰り返さない</string>
+    <string name="repeat_yearly">毎年</string>
+    <string name="repeat_monthly">毎月</string>
+    <string name="repeat_weekly">毎週</string>
+    <string name="repeat_custom">カスタム</string>
+    <string name="repeat_custom_unit">日</string>
+    <string name="anniversary_custom_text">今日で %1$d × %2$d 日</string>
+    <string name="anniversary_year_text">今日で %d 年</string>
+    <string name="anniversary_month_text">今日で %d ヶ月</string>
+    <string name="anniversary_indicator">記念日</string>
+    <string name="anniversary_week_text">今日で %d 週間</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -11,6 +11,7 @@
     <string name="close">閉じる</string>
     <string name="confirm">確認</string>
     <string name="cancel">キャンセル</string>
+    <string name="next">次へ</string>
     <string name="follow_system">システム</string>
     <string name="light_mode">ライト</string>
     <string name="dark_mode">ダーク</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -108,8 +108,14 @@
     <string name="repeat_custom">カスタム</string>
     <string name="repeat_custom_unit">日</string>
     <string name="anniversary_custom_text">今日で %1$d × %2$d 日</string>
-    <string name="anniversary_year_text">今日で %d 年</string>
-    <string name="anniversary_month_text">今日で %d ヶ月</string>
+    <plurals name="anniversary_year_text">
+        <item quantity="other">今日で %d 年</item>
+    </plurals>
+    <plurals name="anniversary_month_text">
+        <item quantity="other">今日で %d ヶ月</item>
+    </plurals>
     <string name="anniversary_indicator">記念日</string>
-    <string name="anniversary_week_text">今日で %d 週間</string>
+    <plurals name="anniversary_week_text">
+        <item quantity="other">今日で %d 週間</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,24 @@
     <string name="restore_failed">恢复失败: %s</string>
     <string name="unknown_error">未知错误</string>
     <string name="select_date">选择日期</string>
+    <!-- 纪念日 / 重复事件 -->
+    <string name="anniversary_section">纪念日设置</string>
+    <string name="anniversary_custom_label">自定义纪念日</string>
+    <string name="anniversary_custom_unit">天/次</string>
+    <string name="anniversary_year">年纪念日</string>
+    <string name="anniversary_month">月纪念日</string>
+    <string name="anniversary_week">周纪念日</string>
+    <string name="anniversary_combined_hint">同时触发时的文案（可选）</string>
+    <string name="repeat_section">自动重置</string>
+    <string name="repeat_none">不重复</string>
+    <string name="repeat_yearly">每年</string>
+    <string name="repeat_monthly">每月</string>
+    <string name="repeat_weekly">每周</string>
+    <string name="repeat_custom">自定义</string>
+    <string name="repeat_custom_unit">天</string>
+    <string name="anniversary_custom_text">到今天已 %1$d 个 %2$d 天</string>
+    <string name="anniversary_year_text">到今天满 %d 年</string>
+    <string name="anniversary_month_text">到今天满 %d 个月</string>
+    <string name="anniversary_indicator">纪念日</string>
+    <string name="anniversary_week_text">到今天满 %d 周</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="close">关闭</string>
     <string name="confirm">确定</string>
     <string name="cancel">取消</string>
+    <string name="next">下一步</string>
     <string name="follow_system">跟随系统</string>
     <string name="light_mode">浅色模式</string>
     <string name="dark_mode">深色模式</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,8 +108,14 @@
     <string name="repeat_custom">自定义</string>
     <string name="repeat_custom_unit">天</string>
     <string name="anniversary_custom_text">到今天已 %1$d 个 %2$d 天</string>
-    <string name="anniversary_year_text">到今天满 %d 年</string>
-    <string name="anniversary_month_text">到今天满 %d 个月</string>
+    <plurals name="anniversary_year_text">
+        <item quantity="other">到今天满 %d 年</item>
+    </plurals>
+    <plurals name="anniversary_month_text">
+        <item quantity="other">到今天满 %d 个月</item>
+    </plurals>
     <string name="anniversary_indicator">纪念日</string>
-    <string name="anniversary_week_text">到今天满 %d 周</string>
+    <plurals name="anniversary_week_text">
+        <item quantity="other">到今天满 %d 周</item>
+    </plurals>
 </resources>

--- a/app/src/test/java/com/kippu/trace/ui/components/EventDateConfigurationTest.kt
+++ b/app/src/test/java/com/kippu/trace/ui/components/EventDateConfigurationTest.kt
@@ -1,0 +1,84 @@
+package com.kippu.trace.ui.components
+
+import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
+import com.kippu.trace.utils.EventDateUtils
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EventDateConfigurationTest {
+    @Test
+    fun normalizingALegacyTimestampDoesNotCountAsChangingItsCalendarDate() {
+        val zone = ZoneId.of("Asia/Shanghai")
+        val legacyTarget = ZonedDateTime.of(
+            2026,
+            8,
+            12,
+            0,
+            30,
+            0,
+            0,
+            zone,
+        ).toInstant().toEpochMilli()
+        val normalizedTarget = EventDateUtils.toUtcMillis(LocalDate.of(2026, 8, 12))
+        val anchor = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 31))
+        val configuration = recurringConfiguration(anchor, legacyTarget)
+
+        val confirmed = configuration.selectDate(
+            selectedDate = normalizedTarget,
+            today = LocalDate.of(2026, 8, 1),
+            legacyZone = zone,
+        )
+
+        assertEquals(normalizedTarget, confirmed.targetDate)
+        assertEquals(anchor, confirmed.repeatAnchorDate)
+    }
+
+    @Test
+    fun selectingADifferentDateReplacesTheRepeatAnchor() {
+        val anchor = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 31))
+        val currentOccurrence = EventDateUtils.toUtcMillis(LocalDate.of(2026, 2, 28))
+        val selectedDate = EventDateUtils.toUtcMillis(LocalDate.of(2026, 3, 15))
+        val configuration = recurringConfiguration(anchor, currentOccurrence)
+
+        val confirmed = configuration.selectDate(
+            selectedDate = selectedDate,
+            today = LocalDate.of(2026, 2, 1),
+        )
+
+        assertEquals(selectedDate, confirmed.repeatAnchorDate)
+    }
+
+    @Test
+    fun confirmingTheCurrentOccurrencePreservesTheOriginalRepeatAnchor() {
+        val anchor = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 31))
+        val currentOccurrence = EventDateUtils.toUtcMillis(LocalDate.of(2026, 2, 28))
+        val configuration = recurringConfiguration(anchor, currentOccurrence)
+
+        val confirmed = configuration.selectDate(
+            selectedDate = currentOccurrence,
+            today = LocalDate.of(2026, 2, 1),
+        )
+
+        assertEquals(anchor, confirmed.repeatAnchorDate)
+    }
+
+    private fun recurringConfiguration(
+        anchor: Long,
+        currentOccurrence: Long,
+    ) = EventDateConfiguration(
+        targetDate = currentOccurrence,
+        mode = DisplayMode.COUNT_DOWN,
+        repeatMode = RepeatMode.MONTHLY,
+        repeatCustomDays = 0,
+        repeatAnchorDate = anchor,
+        customAnniversaryDays = 0,
+        anniversaryYearEnabled = false,
+        anniversaryMonthEnabled = false,
+        anniversaryWeekEnabled = false,
+        anniversaryCombinedText = "",
+    )
+}

--- a/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
+++ b/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
@@ -1,0 +1,41 @@
+package com.kippu.trace.utils
+
+import com.kippu.trace.model.DateEvent
+import com.kippu.trace.model.DisplayMode
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AnniversaryUtilsTest {
+    @Test
+    fun annualDateUsesCombinedTextForYearAndMonthAnniversaries() {
+        val today = LocalDate.now(ZoneId.systemDefault())
+        val targetDate = today.minusYears(4)
+        val targetDateMillis = targetDate
+            .atStartOfDay(ZoneId.of("UTC"))
+            .toInstant()
+            .toEpochMilli()
+
+        val trigger = AnniversaryUtils.checkAllAnniversaries(
+            DateEvent(
+                title = "Annual event",
+                targetDate = targetDateMillis,
+                isFuture = false,
+                mode = DisplayMode.ACCUMULATE,
+                anniversaryYearEnabled = true,
+                anniversaryMonthEnabled = true,
+                anniversaryCombinedText = "4 years and 48 months",
+            )
+        )
+
+        assertEquals(
+            listOf(
+                AnniversaryResult(AnniversaryType.YEAR, count = 4),
+                AnniversaryResult(AnniversaryType.MONTH, count = 48),
+            ),
+            trigger.results,
+        )
+        assertEquals("4 years and 48 months", trigger.displayText())
+    }
+}

--- a/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
+++ b/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
@@ -2,20 +2,100 @@ package com.kippu.trace.utils
 
 import com.kippu.trace.model.DateEvent
 import com.kippu.trace.model.DisplayMode
+import com.kippu.trace.model.RepeatMode
 import java.time.LocalDate
-import java.time.ZoneId
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class AnniversaryUtilsTest {
     @Test
-    fun annualDateUsesCombinedTextForYearAndMonthAnniversaries() {
-        val today = LocalDate.now(ZoneId.systemDefault())
-        val targetDate = today.minusYears(4)
-        val targetDateMillis = targetDate
-            .atStartOfDay(ZoneId.of("UTC"))
-            .toInstant()
-            .toEpochMilli()
+    fun monthlyRepeatKeepsTheOriginalDayAfterAClampedOccurrence() {
+        val next = AnniversaryUtils.advanceTargetDate(
+            currentTargetMillis = EventDateUtils.toUtcMillis(LocalDate.of(2026, 2, 28)),
+            repeatAnchorMillis = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 31)),
+            repeatMode = RepeatMode.MONTHLY,
+            customDays = 0,
+            today = LocalDate.of(2026, 3, 1),
+        )
+
+        assertEquals(
+            EventDateUtils.toUtcMillis(LocalDate.of(2026, 3, 31)),
+            next,
+        )
+    }
+
+    @Test
+    fun yearlyRepeatRestoresLeapDayWhenTheNextLeapYearArrives() {
+        val next = AnniversaryUtils.advanceTargetDate(
+            currentTargetMillis = EventDateUtils.toUtcMillis(LocalDate.of(2027, 2, 28)),
+            repeatAnchorMillis = EventDateUtils.toUtcMillis(LocalDate.of(2024, 2, 29)),
+            repeatMode = RepeatMode.YEARLY,
+            customDays = 0,
+            today = LocalDate.of(2027, 3, 1),
+        )
+
+        assertEquals(
+            EventDateUtils.toUtcMillis(LocalDate.of(2028, 2, 29)),
+            next,
+        )
+    }
+
+    @Test
+    fun customDayRepeatSkipsMissedOccurrencesFromTheOriginalAnchor() {
+        val next = AnniversaryUtils.advanceTargetDate(
+            currentTargetMillis = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 11)),
+            repeatAnchorMillis = EventDateUtils.toUtcMillis(LocalDate.of(2026, 1, 1)),
+            repeatMode = RepeatMode.CUSTOM_DAYS,
+            customDays = 10,
+            today = LocalDate.of(2026, 2, 1),
+        )
+
+        assertEquals(
+            EventDateUtils.toUtcMillis(LocalDate.of(2026, 2, 10)),
+            next,
+        )
+    }
+
+    @Test
+    fun monthlyAnniversaryClampsToTheLastDayOfShortMonths() {
+        val targetDate = LocalDate.of(2026, 1, 31)
+
+        val results = AnniversaryUtils.checkSystemAnniversary(
+            targetDateMillis = EventDateUtils.toUtcMillis(targetDate),
+            yearEnabled = false,
+            monthEnabled = true,
+            weekEnabled = false,
+            today = LocalDate.of(2026, 2, 28),
+        )
+
+        assertEquals(
+            listOf(AnniversaryResult(AnniversaryType.MONTH, count = 1)),
+            results,
+        )
+    }
+
+    @Test
+    fun leapDayYearAnniversaryClampsToFebruaryEndInNonLeapYears() {
+        val targetDate = LocalDate.of(2024, 2, 29)
+
+        val results = AnniversaryUtils.checkSystemAnniversary(
+            targetDateMillis = EventDateUtils.toUtcMillis(targetDate),
+            yearEnabled = true,
+            monthEnabled = false,
+            weekEnabled = false,
+            today = LocalDate.of(2025, 2, 28),
+        )
+
+        assertEquals(
+            listOf(AnniversaryResult(AnniversaryType.YEAR, count = 1)),
+            results,
+        )
+    }
+
+    @Test
+    fun annualDateIncludesYearMonthAndTheConfiguredCombinedText() {
+        val today = LocalDate.of(2026, 8, 11)
+        val targetDateMillis = EventDateUtils.toUtcMillis(LocalDate.of(2022, 8, 11))
 
         val trigger = AnniversaryUtils.checkAllAnniversaries(
             DateEvent(
@@ -26,7 +106,8 @@ class AnniversaryUtilsTest {
                 anniversaryYearEnabled = true,
                 anniversaryMonthEnabled = true,
                 anniversaryCombinedText = "4 years and 48 months",
-            )
+            ),
+            today = today,
         )
 
         assertEquals(
@@ -36,5 +117,6 @@ class AnniversaryUtilsTest {
             ),
             trigger.results,
         )
+        assertEquals("4 years and 48 months", trigger.combinedText)
     }
 }

--- a/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
+++ b/app/src/test/java/com/kippu/trace/utils/AnniversaryUtilsTest.kt
@@ -36,6 +36,5 @@ class AnniversaryUtilsTest {
             ),
             trigger.results,
         )
-        assertEquals("4 years and 48 months", trigger.displayText())
     }
 }

--- a/app/src/test/java/com/kippu/trace/utils/EventDateUtilsTest.kt
+++ b/app/src/test/java/com/kippu/trace/utils/EventDateUtilsTest.kt
@@ -1,0 +1,67 @@
+package com.kippu.trace.utils
+
+import com.kippu.trace.model.DisplayMode
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EventDateUtilsTest {
+    @Test
+    fun utcMidnightEncodingDoesNotShiftInANegativeTimeZone() {
+        val date = LocalDate.of(2026, 8, 12)
+
+        assertEquals(
+            date,
+            EventDateUtils.fromStoredMillis(
+                EventDateUtils.toUtcMillis(date),
+                ZoneId.of("America/Los_Angeles"),
+            ),
+        )
+    }
+
+    @Test
+    fun legacyNonMidnightTimestampKeepsItsOriginalLocalDate() {
+        val zone = ZoneId.of("Asia/Shanghai")
+        val legacyTimestamp = ZonedDateTime.of(
+            2026,
+            8,
+            12,
+            0,
+            30,
+            0,
+            0,
+            zone,
+        ).toInstant().toEpochMilli()
+
+        assertEquals(
+            LocalDate.of(2026, 8, 12),
+            EventDateUtils.fromStoredMillis(legacyTimestamp, zone),
+        )
+    }
+
+    @Test
+    fun laterCalendarDateUsesCountdownMode() {
+        val today = LocalDate.of(2026, 8, 11)
+
+        assertEquals(
+            DisplayMode.COUNT_DOWN,
+            EventDateUtils.displayModeFor(
+                EventDateUtils.toUtcMillis(today.plusDays(1)),
+                today,
+            ),
+        )
+    }
+
+    @Test
+    fun utcMidnightForTodayUsesAccumulateModeForTheWholeLocalDay() {
+        val today = LocalDate.of(2026, 8, 11)
+        val selectedDateMillis = EventDateUtils.toUtcMillis(today)
+
+        assertEquals(
+            DisplayMode.ACCUMULATE,
+            EventDateUtils.displayModeFor(selectedDateMillis, today),
+        )
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# TimeTrace 文档
+
+欢迎阅读 TimeTrace（时痕）的技术文档。这里记录了项目的架构设计、开发指南和功能说明。
+
+## 文档目录
+
+| 文档 | 说明 |
+|------|------|
+| [架构说明](./architecture.md) | 项目整体架构、分层设计、数据流与核心模块 |
+| [开发指南](./development.md) | 环境搭建、编译运行、代码规范与贡献流程 |
+| [小组件指南](./widget-guide.md) | Android App Widget 的布局、更新机制与配置说明 |
+| [导入/导出格式](./import-export-format.md) | ZIP 备份包的数据结构、字段定义与 JSON Schema |
+
+## 项目简介
+
+TimeTrace 是一个基于 Kotlin + Jetpack Compose 的 Android 日期追踪应用。帮助用户记录生命中重要的时刻——无论是未来的期待计时，还是过往经历的累积记录。
+
+- **技术栈**：Kotlin / Jetpack Compose / Material 3 / Room / Coil
+- **最低 SDK**：Android 8.0 (API 26)
+- **目标 SDK**：34
+- **许可证**：MIT
+
+## 快速链接
+
+- [GitHub 仓库](https://github.com/KIPPUDESU/KIPPU_Trace)
+- [Telegram 社区](https://t.me/KIPPU_Trace)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,165 @@
+# 架构说明
+
+## 整体架构
+
+TimeTrace 采用 MVVM（Model-View-ViewModel）架构，结合 Android Jetpack 组件构建。整个应用遵循单向数据流原则，从数据层向上流动到 UI 层，用户操作通过 ViewModel 向下传递到数据层。
+
+```
+┌─────────────────────────────────────┐
+│              UI Layer               │
+│  (Compose Screens / Components)     │
+├─────────────────────────────────────┤
+│          ViewModel Layer            │
+│        (EventViewModel)             │
+├─────────────────────────────────────┤
+│          Data Layer                 │
+│  (Room Database / Repository)       │
+├─────────────────────────────────────┤
+│          Model Layer                │
+│        (DateEvent)                  │
+└─────────────────────────────────────┘
+```
+
+## 包结构
+
+```
+com.kippu.trace/
+├── data/           # 数据持久化层
+│   ├── AppDatabase.kt      # Room 数据库定义
+│   ├── Converters.kt       # 类型转换器
+│   └── EventRepository.kt  # 数据仓库
+├── model/          # 数据模型
+│   └── DateEvent.kt        # 事件实体 & 枚举
+├── ui/             # 用户界面
+│   ├── components/         # 可复用组件
+│   │   ├── AnniversaryConfigSection.kt  # 纪念日配置组件
+│   │   ├── NormalEventCard.kt           # 普通事件卡片
+│   │   └── PinnedEventCard.kt           # 置顶事件卡片
+│   ├── screens/            # 页面
+│   │   ├── HomeScreen.kt       # 主页
+│   │   ├── DetailScreen.kt     # 详情页
+│   │   ├── EditorScreen.kt     # 编辑页
+│   │   └── SettingsScreen.kt   # 设置页
+│   └── theme/              # 主题
+│       ├── Color.kt            # 色板定义
+│       ├── Theme.kt            # Material 3 主题
+│       └── Type.kt             # 字体排版
+├── utils/          # 工具类
+│   ├── AnniversaryUtils.kt    # 纪念日计算
+│   ├── BackupManager.kt       # 备份导入导出
+│   ├── FileUtils.kt           # 文件操作
+│   ├── ImageUtils.kt          # 图片处理
+│   ├── LanguagePreferences.kt # 语言偏好
+│   ├── TextUtils.kt           # 文本处理
+│   ├── ThemePreferences.kt    # 主题偏好
+│   ├── TimeUtils.kt           # 时间计算与显示
+│   └── UIUtils.kt             # UI 辅助
+├── viewmodel/      # ViewModel
+│   └── EventViewModel.kt     # 事件业务逻辑
+├── widget/         # 桌面小组件
+│   ├── TraceWidgetBackgroundRenderer.kt  # 小组件背景渲染
+│   ├── TraceWidgetProvider.kt            # 小组件 Provider
+│   ├── TraceWidgetProviders.kt           # 多尺寸 Provider
+│   ├── TraceWidgetSize.kt                # 小组件尺寸定义
+│   └── TraceWidgetUpdater.kt             # 小组件更新触发
+├── MainActivity.kt            # 主 Activity 入口
+└── WidgetConfigActivity.kt    # 小组件配置 Activity
+```
+
+## 数据模型
+
+### DateEvent
+
+核心数据实体，使用 Room 持久化存储。表名 `date_events`。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | `Long` | 主键，自增 |
+| `title` | `String` | 事件标题 |
+| `targetDate` | `Long` | 目标日期（毫秒时间戳） |
+| `isFuture` | `Boolean` | 语义判断：未来/过去 |
+| `isLunar` | `Boolean` | 是否农历日期 |
+| `mode` | `DisplayMode` | 显示模式（倒数/累计） |
+| `backgroundUri` | `String?` | 背景图片 URI |
+| `isPinned` | `Boolean` | 是否置顶 |
+| `maskOpacity` | `Float` | 遮罩不透明度 (0.0~1.0) |
+| `position` | `Int` | 排序位置 |
+| `repeatMode` | `RepeatMode` | 倒数重复模式 |
+| `repeatCustomDays` | `Int` | 自定义重复天数 |
+| `customAnniversaryDays` | `Int` | 自定义纪念日天数 |
+| `anniversaryYearEnabled` | `Boolean` | 周年纪念日开关 |
+| `anniversaryMonthEnabled` | `Boolean` | 月纪念日开关 |
+| `anniversaryWeekEnabled` | `Boolean` | 周纪念日开关 |
+| `anniversaryCombinedText` | `String` | 多纪念日合并文案 |
+
+### 枚举类型
+
+**DisplayMode（显示模式）**
+- `COUNT_DOWN` — 倒数模式，显示距离目标日期还有多少天
+- `ACCUMULATE` — 累计模式，显示从目标日期起已经过了多少天
+
+**RepeatMode（重复模式）**
+- `NONE` — 不重复
+- `YEARLY` — 每年
+- `MONTHLY` — 每月
+- `WEEKLY` — 每周
+- `CUSTOM_DAYS` — 自定义天数
+
+## 数据流
+
+### 读取流程
+
+```
+Room DB → EventDao (Flow) → EventRepository → EventViewModel (StateFlow) → Compose UI
+```
+
+1. Room 数据库通过 `EventDao.getAllEvents()` 返回 `Flow<List<DateEvent>>`
+2. `EventRepository` 封装 DAO，对外暴露 Flow
+3. `EventViewModel` 使用 `stateIn()` 将 Flow 转换为 `StateFlow`
+4. Compose UI 通过 `collectAsState()` 订阅 StateFlow，自动重组
+
+### 写入流程
+
+```
+Compose UI → EventViewModel (viewModelScope) → EventRepository → EventDao → Room DB
+                                                      ↓
+                                            TraceWidgetUpdater
+```
+
+1. 用户操作触发 ViewModel 方法（`addEvent` / `deleteEvent` / `updateEventsOrder`）
+2. ViewModel 在 `viewModelScope` 中启动协程执行数据库操作
+3. 写操作完成后自动触发小组件更新
+
+## 核心模块
+
+### EventViewModel
+
+应用的唯一 ViewModel（`AndroidViewModel`），管理所有事件状态：
+
+- **`allEvents`**：`StateFlow<List<DateEvent>>`，UI 层的数据源，按置顶优先 + 位置 + ID 排序
+- **`checkAndAdvanceCountdowns()`**：初始化时自动检查所有倒数事件，对已过期且设置了重复规则的事件自动推进目标日期
+- **`addEvent` / `deleteEvent`**：增删事件，操作后自动触发小组件刷新
+- **`exportBackup` / `importBackup`**：通过 `BackupManager` 实现 ZIP 格式的数据导入导出
+
+### 主题系统
+
+- 基于 Material 3 设计语言
+- 支持深色/浅色模式，通过 `ThemePreferences` 管理
+- 色板和字体定义在 `ui/theme/` 中，统一管理
+
+### 多语言
+
+原生支持简体中文、英语、日语。通过 Android 标准的 `strings.xml` 资源文件实现，`LanguagePreferences` 管理语言切换。
+
+### 小组件
+
+详见 [小组件指南](./widget-guide.md)。
+
+## 导航
+
+应用使用 Jetpack Navigation Compose 进行页面路由：
+
+- **主页** (`HomeScreen`) — 事件列表，默认首页
+- **编辑页** (`EditorScreen`) — 新建/编辑事件
+- **详情页** (`DetailScreen`) — 事件详情展示，支持全屏背景海报预览
+- **设置页** (`SettingsScreen`) — 主题切换、语言切换、备份导入导出

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,7 @@ com.kippu.trace/
 | `position` | `Int` | 排序位置 |
 | `repeatMode` | `RepeatMode` | 倒数重复模式 |
 | `repeatCustomDays` | `Int` | 自定义重复天数 |
+| `repeatAnchorDate` | `Long?` | 重复计算的原始锚点日期 |
 | `customAnniversaryDays` | `Int` | 自定义纪念日天数 |
 | `anniversaryYearEnabled` | `Boolean` | 周年纪念日开关 |
 | `anniversaryMonthEnabled` | `Boolean` | 月纪念日开关 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,145 @@
+# 开发指南
+
+## 环境要求
+
+| 工具 | 版本 |
+|------|------|
+| Android Studio | Ladybug (2024.2.1) 或更高 |
+| JDK | 17 |
+| Android SDK | 34+ |
+| Gradle | 8.x（项目自带 Wrapper） |
+| Kotlin | 2.x |
+
+## 快速开始
+
+### 1. 克隆仓库
+
+```bash
+git clone https://github.com/KIPPUDESU/KIPPU_Trace.git
+cd KIPPU_Trace
+```
+
+### 2. 用 Android Studio 打开项目
+
+直接打开项目根目录，Android Studio 会自动识别 Gradle 项目结构。
+
+### 3. 等待 Gradle 同步
+
+首次打开会下载依赖，需要保持网络通畅。同步完成后 Build 窗口显示 "BUILD SUCCESSFUL"。
+
+### 4. 运行
+
+连接 Android 设备（或启动模拟器），点击 Android Studio 工具栏的 **Run** 按钮（绿色三角形），或使用命令行：
+
+```bash
+./gradlew installDebug
+```
+
+## 项目配置
+
+### build.gradle.kts（应用模块）
+
+关键配置项：
+
+```kotlin
+android {
+    namespace = "com.kippu.trace"
+    compileSdk = 34
+    defaultConfig {
+        applicationId = "com.kippu.trace"
+        minSdk = 26          // Android 8.0
+        targetSdk = 34
+        versionCode = 7
+        versionName = "2.2.0"
+    }
+}
+```
+
+### 版本号管理
+
+- `versionCode`：整数，每次发布递增
+- `versionName`：语义化版本号，如 `2.2.0`
+
+## 依赖说明
+
+| 依赖 | 用途 |
+|------|------|
+| **Jetpack Compose** | UI 框架，Material 3 设计 |
+| **Compose BOM** | 统一管理 Compose 相关库版本 |
+| **Navigation Compose** | 页面路由导航 |
+| **Room** | SQLite 数据库 ORM |
+| **Coil** | 图片加载（支持 Compose） |
+| **KSP** | Room 编译期注解处理（替代 kapt） |
+
+## 代码规范
+
+### 命名约定
+
+- **文件名**：PascalCase，如 `HomeScreen.kt`
+- **类名**：PascalCase，如 `EventViewModel`
+- **函数/变量**：camelCase，如 `addEvent()`
+- **常量**：UPPER_SNAKE_CASE，如 `COUNT_DOWN`
+- **包名**：全小写，如 `com.kippu.trace.viewmodel`
+
+### 架构约定
+
+1. **UI 组件放在 `ui/components/`**：可复用的 Compose 组件
+2. **页面放在 `ui/screens/`**：完整的页面级 Composable
+3. **数据操作通过 Repository**：不直接在 ViewModel 中操作 DAO
+4. **协程通过 viewModelScope 管理**：避免手动管理 Job 生命周期
+
+### Compose 规范
+
+- 预览函数使用 `@Preview` 注解，命名以 `Preview` 结尾
+- 状态提升：将状态和事件回调作为参数传入 Composable
+- 避免在 Composable 中直接执行副作用，使用 `LaunchedEffect` 或 `SideEffect`
+
+## 构建变体
+
+### Debug
+
+- 启用 Compose UI Tooling
+- 启用 UI Test Manifest
+- 未混淆
+
+### Release
+
+- 开启代码混淆（ProGuard）
+- 使用 `proguard-android-optimize.txt` 优化规则
+
+## 测试
+
+项目使用标准 Android 测试框架：
+
+```bash
+# 单元测试
+./gradlew test
+
+# 仪器化测试（需要设备/模拟器）
+./gradlew connectedAndroidTest
+```
+
+测试依赖：
+- **JUnit** — 单元测试
+- **Espresso** — UI 测试
+- **Compose UI Test** — Compose 专用测试
+
+## 常见问题
+
+### Gradle 同步失败
+
+1. 检查网络连接，确保能访问 `google()` 和 `mavenCentral()` 仓库
+2. 在 Android Studio 中：File → Invalidate Caches → Invalidate and Restart
+3. 删除 `~/.gradle/caches/` 后重试
+
+### 编译错误：SDK 版本
+
+确保 SDK Manager 中已安装：
+- Android SDK Platform 34
+- Android SDK Build-Tools 34+
+
+### Room 编译错误
+
+Room 使用 KSP（Kotlin Symbol Processing）生成代码。如果出现符号找不到的错误：
+1. 执行 `./gradlew clean` 后重新编译
+2. 确认 `ksp` 插件已在 `build.gradle.kts` 中声明

--- a/docs/import-export-format.md
+++ b/docs/import-export-format.md
@@ -1,0 +1,224 @@
+# KIPPU Trace 导入/导出数据格式说明
+
+## 概述
+
+KIPPU Trace 使用 **ZIP 压缩包** 作为导入/导出的文件格式（`.zip`）。ZIP 包内包含一个 JSON 数据文件以及可选的背景图片文件夹。
+
+## ZIP 包结构
+
+```
+backup.zip
+├── events.json          # 事件数据（必需）
+└── backgrounds/         # 背景图片（可选）
+    ├── abc123.jpg
+    └── def456.png
+```
+
+## events.json 格式
+
+`events.json` 是一个 **JSON 数组**，每个元素代表一个事件对象。
+
+### 示例
+
+```json
+[
+  {
+    "id": 1,
+    "title": "生日倒计时",
+    "targetDate": 1735689600000,
+    "isFuture": true,
+    "isLunar": false,
+    "mode": "COUNT_DOWN",
+    "isPinned": true,
+    "maskOpacity": 0.3,
+    "backgroundFile": "abc123.jpg",
+    "repeatMode": "YEARLY",
+    "repeatCustomDays": 0,
+    "anniversaryYearEnabled": false,
+    "anniversaryMonthEnabled": false,
+    "anniversaryWeekEnabled": false,
+    "anniversaryCombinedText": ""
+  },
+  {
+    "id": 2,
+    "title": "恋爱纪念日",
+    "targetDate": 1609459200000,
+    "isFuture": false,
+    "isLunar": false,
+    "mode": "ACCUMULATE",
+    "isPinned": false,
+    "maskOpacity": 0.5,
+    "repeatMode": "NONE",
+    "customAnniversaryDays": 100,
+    "anniversaryYearEnabled": true,
+    "anniversaryMonthEnabled": true,
+    "anniversaryWeekEnabled": false,
+    "anniversaryCombinedText": "今天是我们在一起的纪念日"
+  }
+]
+```
+
+### 字段说明
+
+| 字段                        | 类型        | 必需    | 默认值      | 说明                                                              |
+|---------------------------|-----------|-------|----------|-----------------------------------------------------------------|
+| `id`                      | `integer` | ✅     | -        | 事件唯一标识，导入时会覆盖同 ID 的已有事件                                         |
+| `title`                   | `string`  | ✅     | -        | 事件标题                                                            |
+| `targetDate`              | `integer` | ✅     | -        | 目标日期，**毫秒级 Unix 时间戳**（`Date.now()` 格式）                          |
+| `isFuture`                | `boolean` | ✅     | -        | 目标日期是否在未来。`true`=未来日期，`false`=过去日期。影响显示文案（"还有 X 天" vs "已经 X 天"） |
+| `isLunar`                 | `boolean` | ❌     | `false`  | 是否为农历日期                                                         |
+| `mode`                    | `string`  | ✅     | -        | 显示模式，取值见下方枚举                                                    |
+| `isPinned`                | `boolean` | ❌     | `false`  | 是否置顶                                                            |
+| `maskOpacity`             | `number`  | ❌     | `0.3`    | 背景遮罩不透明度，取值范围 `0.0` ~ `1.0`                                     |
+| `backgroundFile`          | `string`  | ❌     | -        | 背景图片文件名（不含路径）。对应的图片文件需放在 `backgrounds/` 目录下                     |
+| `repeatMode`              | `string`  | ❌     | `"NONE"` | 倒数模式自动重置规则，取值见下方枚举                                              |
+| `repeatCustomDays`        | `integer` | ❌     | `0`      | 自定义重置天数（仅 `repeatMode` 为 `CUSTOM_DAYS` 时有效）                     |
+| `customAnniversaryDays`   | `integer` | ❌     | `0`      | 自定义纪念日间隔天数（`0` 表示不启用）                                           |
+| `anniversaryYearEnabled`  | `boolean` | ❌     | `false`  | 是否启用年纪念日                                                        |
+| `anniversaryMonthEnabled` | `boolean` | ❌     | `false`  | 是否启用月纪念日                                                        |
+| `anniversaryWeekEnabled`  | `boolean` | ❌     | `false`  | 是否启用周纪念日                                                        |
+| `anniversaryCombinedText` | `string`  | ❌     | `""`     | 多纪念日同时触发时的自定义合并文案                                               |
+
+### `mode` 枚举值
+
+| 值            | 含义                     |
+|--------------|------------------------|
+| `COUNT_DOWN` | 倒数模式 — 显示距离目标日期还有多少天   |
+| `ACCUMULATE` | 累计模式 — 显示从目标日期起已经过了多少天 |
+
+### `repeatMode` 枚举值
+
+| 值             | 含义                                |
+|---------------|-----------------------------------|
+| `NONE`        | 不重复（默认）                           |
+| `YEARLY`      | 每年重置                              |
+| `MONTHLY`     | 每月重置                              |
+| `WEEKLY`      | 每周重置                              |
+| `CUSTOM_DAYS` | 自定义天数重置（配合 `repeatCustomDays` 使用） |
+
+### 注意事项
+
+1. **`position` 字段不导出** — 事件的排序位置由列表顺序决定，导入后按 ID 顺序重建。
+2. **`backgroundFile` 为 null 或不存在时** — 表示该事件没有自定义背景图。
+3. **图片文件** — 如果 `backgroundFile` 指定了文件名，但 ZIP 中 `backgrounds/` 目录下找不到对应文件，该事件的背景图将为空白。
+4. **ID 冲突** — 导入时采用"清空全部 + 批量插入"策略，所有已有数据会被替换。
+
+---
+
+## JSON Schema
+
+```jsonschema
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kippu.trace/schema/events.json",
+  "title": "KIPPU Trace 导出数据",
+  "description": "KIPPU Trace 事件数据的导入/导出格式",
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/DateEvent"
+  },
+  "$defs": {
+    "DateEvent": {
+      "type": "object",
+      "required": ["id", "title", "targetDate", "isFuture", "mode"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "事件唯一标识"
+        },
+        "title": {
+          "type": "string",
+          "description": "事件标题"
+        },
+        "targetDate": {
+          "type": "integer",
+          "description": "目标日期，毫秒级 Unix 时间戳",
+          "examples": [1735689600000]
+        },
+        "isFuture": {
+          "type": "boolean",
+          "description": "目标日期是否在未来。true=未来, false=过去"
+        },
+        "isLunar": {
+          "type": "boolean",
+          "description": "是否为农历日期",
+          "default": false
+        },
+        "mode": {
+          "type": "string",
+          "description": "显示模式",
+          "enum": ["COUNT_DOWN", "ACCUMULATE"]
+        },
+        "isPinned": {
+          "type": "boolean",
+          "description": "是否置顶",
+          "default": false
+        },
+        "maskOpacity": {
+          "type": "number",
+          "description": "背景遮罩不透明度 (0.0 ~ 1.0)",
+          "default": 0.3,
+          "minimum": 0.0,
+          "maximum": 1.0
+        },
+        "backgroundFile": {
+          "type": "string",
+          "description": "背景图片文件名，对应 backgrounds/ 目录下的文件"
+        },
+        "repeatMode": {
+          "type": "string",
+          "description": "倒数模式自动重置规则",
+          "enum": ["NONE", "YEARLY", "MONTHLY", "WEEKLY", "CUSTOM_DAYS"],
+          "default": "NONE"
+        },
+        "repeatCustomDays": {
+          "type": "integer",
+          "description": "自定义重置天数",
+          "default": 0
+        },
+        "customAnniversaryDays": {
+          "type": "integer",
+          "description": "自定义纪念日间隔天数，0 表示不启用",
+          "default": 0
+        },
+        "anniversaryYearEnabled": {
+          "type": "boolean",
+          "description": "是否启用年纪念日",
+          "default": false
+        },
+        "anniversaryMonthEnabled": {
+          "type": "boolean",
+          "description": "是否启用月纪念日",
+          "default": false
+        },
+        "anniversaryWeekEnabled": {
+          "type": "boolean",
+          "description": "是否启用周纪念日",
+          "default": false
+        },
+        "anniversaryCombinedText": {
+          "type": "string",
+          "description": "多纪念日同时触发时的自定义合并文案",
+          "default": ""
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 手动构建备份
+
+如果你想手动创建一个可被 KIPPU Trace 识别的备份文件：
+
+1. 创建 `events.json`，按上述格式填写事件数据。
+2. （可选）创建 `backgrounds/` 文件夹，放入背景图片。
+3. 将 `events.json` 和 `backgrounds/` 打包为 ZIP 文件（确保文件和文件夹在 ZIP 根目录下，不要嵌套多余层级）。
+4. 将 `.zip` 文件传输到手机，通过 KIPPU Trace 的"导入备份"功能选择该文件即可。
+
+```bash
+# 示例：macOS/Linux 命令行打包
+zip -r backup.zip events.json backgrounds/
+```

--- a/docs/import-export-format.md
+++ b/docs/import-export-format.md
@@ -34,6 +34,7 @@ backup.zip
     "backgroundFile": "abc123.jpg",
     "repeatMode": "YEARLY",
     "repeatCustomDays": 0,
+    "repeatAnchorDate": 1735689600000,
     "anniversaryYearEnabled": false,
     "anniversaryMonthEnabled": false,
     "anniversaryWeekEnabled": false,
@@ -73,6 +74,7 @@ backup.zip
 | `backgroundFile`          | `string`  | ❌     | -        | 背景图片文件名（不含路径）。对应的图片文件需放在 `backgrounds/` 目录下                     |
 | `repeatMode`              | `string`  | ❌     | `"NONE"` | 倒数模式自动重置规则，取值见下方枚举                                              |
 | `repeatCustomDays`        | `integer` | ❌     | `0`      | 自定义重置天数（仅 `repeatMode` 为 `CUSTOM_DAYS` 时有效）                     |
+| `repeatAnchorDate`        | `integer` | ❌     | `targetDate` | 重复计算的原始锚点日期，毫秒级 Unix 时间戳；旧备份缺失时使用 `targetDate`              |
 | `customAnniversaryDays`   | `integer` | ❌     | `0`      | 自定义纪念日间隔天数（`0` 表示不启用）                                           |
 | `anniversaryYearEnabled`  | `boolean` | ❌     | `false`  | 是否启用年纪念日                                                        |
 | `anniversaryMonthEnabled` | `boolean` | ❌     | `false`  | 是否启用月纪念日                                                        |
@@ -175,6 +177,10 @@ backup.zip
           "type": "integer",
           "description": "自定义重置天数",
           "default": 0
+        },
+        "repeatAnchorDate": {
+          "type": "integer",
+          "description": "重复计算的原始锚点日期，毫秒级 Unix 时间戳；缺失时使用 targetDate"
         },
         "customAnniversaryDays": {
           "type": "integer",

--- a/docs/widget-guide.md
+++ b/docs/widget-guide.md
@@ -1,0 +1,107 @@
+# 小组件指南
+
+## 概述
+
+TimeTrace 支持 Android App Widget，用户可以在桌面上直接查看他们关注的事件，无需打开应用。
+
+## 文件结构
+
+```
+widget/
+├── TraceWidgetProvider.kt            # 小组件 Provider（基础）
+├── TraceWidgetProviders.kt           # 多尺寸 Provider 注册
+├── TraceWidgetUpdater.kt             # 更新触发逻辑
+├── TraceWidgetSize.kt                # 尺寸与布局参数
+└── TraceWidgetBackgroundRenderer.kt  # 背景渲染
+```
+
+## 小组件尺寸
+
+| 尺寸 | 最小宽高 | 用途 |
+|------|----------|------|
+| 小 (2×1) | 200×100dp | 紧凑的单事件展示 |
+| 中 (4×2) | 360×150dp | 标准卡片布局 |
+| 大 (4×4) | 360×360dp | 多事件列表或大卡片 |
+
+## 更新机制
+
+### 触发时机
+
+小组件在以下情况会被更新：
+
+1. **数据变更时**：用户添加/删除/编辑/排序事件后，`EventViewModel` 调用 `TraceWidgetUpdater.requestAllUpdate()`
+2. **倒计时自动推进后**：`checkAndAdvanceCountdowns()` 完成重复事件的日期推进后触发
+3. **导入备份后**：从 ZIP 恢复数据完成后触发
+4. **系统定时更新**：由 `updatePeriodMillis` 控制（在 `app_widget_info.xml` 中配置）
+
+### 更新流程
+
+```
+数据变更 → EventViewModel → TraceWidgetUpdater.requestAllUpdate()
+                                    ↓
+                          AppWidgetManager.updateAppWidget()
+                                    ↓
+                          TraceWidgetProvider.onUpdate()
+                                    ↓
+                          RemoteViews 渲染
+```
+
+### TraceWidgetUpdater
+
+`TraceWidgetUpdater` 是触发小组件刷新的统一入口：
+
+```kotlin
+// 请求更新所有已放置的小组件实例
+TraceWidgetUpdater.requestAllUpdate(context)
+```
+
+这是一个静态工具方法，可以在 ViewModel、Activity 等任何上下文中调用。
+
+## 小组件配置
+
+用户通过 `WidgetConfigActivity` 配置小组件参数：
+
+1. 用户在桌面长按 → 选择 TimeTrace 小组件
+2. 系统启动 `WidgetConfigActivity`
+3. 用户选择要显示的事件和小组件样式
+4. 确认后小组件放置在桌面
+
+## 背景渲染
+
+`TraceWidgetBackgroundRenderer` 负责小组件背景的绘制：
+
+- 支持自定义背景图片（从应用内部存储读取）
+- 支持遮罩层（不透明度可配）
+- 适配小组件容器的圆角和尺寸
+
+由于 App Widget 使用 `RemoteViews`（运行在 Launcher 进程），背景图片需要渲染为 Bitmap 后通过 `ImageView` 设置，不能直接使用 Compose 组件。
+
+## 数据共享
+
+小组件数据通过以下方式获取：
+
+1. **Room 数据库直接读取**：小组件 Provider 可以直接查询 `AppDatabase`
+2. **SharedPreferences**：小组件配置参数存储（如选择的事件 ID、背景设置）
+
+## 开发注意事项
+
+### RemoteViews 限制
+
+App Widget 使用 `RemoteViews`，仅支持有限的 View 类型：
+- `TextView`、`ImageView`、`LinearLayout`、`RelativeLayout` 等基础组件
+- **不支持** Compose、WebView、自定义 View 等
+
+这意味着小组件的 UI 需要用 XML 布局文件定义，逻辑在 `TraceWidgetProvider` 中用 `RemoteViews` API 构建。
+
+### 性能考虑
+
+- 小组件更新操作应尽量轻量，避免在 `onUpdate()` 中执行耗时 IO
+- 数据库查询应在后台线程执行
+- Bitmap 渲染注意内存管理，及时回收
+
+### 测试
+
+测试小组件时注意：
+- 模拟器可能不完全支持小组件的所有行为
+- 真机测试建议在不同 Launcher（系统桌面、Nova、Lawnchair 等）上验证视觉效果
+- 小组件尺寸在不同设备/DPI 上可能有差异

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ android.enableJetifier=true
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 kotlin.code.style=official
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary

This PR introduces anniversary detection for accumulated mode, automatic target-date advancement for countdown mode with repeat rules, a two-step date-picker wizard, and comprehensive project documentation.

## Features

### Anniversary Display (累计模式纪念日)
- Detect anniversaries for accumulated mode: year, month, week, and custom N-day intervals
- Anniversary gold text replaces the date display on cards (NormalEventCard, PinnedEventCard) and detail screen when triggered
- Custom combined text for multi-anniversary triggers (e.g., "3周年 & 36个月纪念日")
- New `AnniversaryConfigSection` composable with switches and custom-day input
- New `AnniversaryUtils.checkAllAnniversaries()` for anniversary calculation

### Countdown Auto-Repeat (倒数模式自动重置)
- Auto-advance target date when countdown passes and the app resumes
- Supports yearly, monthly, weekly, and custom-N-day repeat modes
- `AtomicBoolean` guard prevents concurrent coroutine execution from `init` + `onResume`

### Two-Step Date-Picker Wizard
- Replaces separate DatePicker + AnniversaryConfig dialogs with a single in-place transition dialog
- Step 1: select date (shows "Next" instead of "Confirm")
- Step 2: configure reset/anniversary settings based on mode (COUNT_DOWN / ACCUMULATE)
- Confirm on second step closes the dialog
- AnniversaryConfigSection removed from the main editor body

### Bug Fixes
- **Timezone encoding mismatch**: `advanceTargetDate` was storing system-zone midnight instead of UTC midnight, breaking anniversary calculations after auto-advance
- **PinnedEventCard anniversary**: type 1 and 2 (short/medium-title) layouts were missing anniversary gold styling
- **Unnecessary Room writes**: use `mapNotNull` instead of `map` to only update events that changed

### Code Quality
- Extract `subtitleText`/`subtitleColor` in NormalEventCard to eliminate copy-pasted conditional logic
- Extract `buildTitleWithPrefixAnnotatedString` to UIUtils, deduplicating ~25 lines of annotated-string building

### Backup Manager
- Add repeat and anniversary settings to backup/restore flow

### Documentation
- `docs/README.md` — docs index
- `docs/architecture.md` — system architecture overview
- `docs/development.md` — development guide
- `docs/import-export-format.md` — import/export data format spec
- `docs/widget-guide.md` — widget usage guide

## Schema Migration
Room DB version 2 → 3: new `RepeatMode` enum + anniversary fields (`repeatMode`, `repeatCustomDays`, `customAnniversaryDays`, `anniversaryYearEnabled`, `anniversaryMonthEnabled`, `anniversaryWeekEnabled`, `anniversaryCombinedText`)

## Files Changed
24 files, +1737 / −201

## ⚠️ Attention
**NOT FULLY TESTED** — manual verification on a physical device is recommended before merging.